### PR TITLE
Expand macros before pre-evaluating defuns, during parsing

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -297,7 +297,7 @@ impl Parser<'_, '_> {
     }
 
     fn parse_list(&mut self, start_span: Span) -> Result<TulispObject, Error> {
-        let inner = TulispObject::nil();
+        let mut inner = TulispObject::nil();
         let mut got_dot = false;
         loop {
             let Some(token) = self.tokenizer.peek() else {
@@ -348,6 +348,7 @@ impl Parser<'_, '_> {
         if let Ok("defun" | "defmacro" | "lambda") =
             inner.car()?.as_symbol().as_ref().map(|x| x.as_str())
         {
+            inner = macroexpand(self.ctx, inner)?;
             eval(self.ctx, &inner)?;
             // recursively update ctx obj in case it is a recursive function.
             recursive_update_ctxobj(self.ctx, &inner)?;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -176,6 +176,19 @@ fn test_defun() -> Result<(), Error> {
     }
     tulisp_assert! {
         program: r##"
+        (let ((res (test)))
+
+        (defun test ()
+          (let* ((a 5)
+                 (c 7))
+            (when-let ((b 6))
+              (list a b c))))
+        res)
+        "##,
+        result: "'(5 6 7)",
+    }
+    tulisp_assert! {
+        program: r##"
             (defun add (x &rest y)
              (if y
                  (append y (list x))


### PR DESCRIPTION
And add a test that calls a function (with multi-level macros), before it's definition is evaluated in the main eval step.  So only the pre-evaluated code is available, and if its macros need to have been expanded already.

Hopefully that fixes all the macroexpand edge cases.