### PR TITLE
Add a hash table implementation

### DIFF
--- a/src/builtin/functions/hash_table.rs
+++ b/src/builtin/functions/hash_table.rs
@@ -1,0 +1,69 @@
+use std::{any::Any, cell::RefCell, collections::HashMap, rc::Rc};
+
+use tulisp_proc_macros::crate_fn;
+
+use crate::{Error, TulispContext, TulispObject};
+
+struct TulispObjectEql(TulispObject);
+
+impl std::hash::Hash for TulispObjectEql {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        if self.0.integerp() {
+            self.0.as_int().unwrap().hash(state);
+        } else if self.0.floatp() {
+            self.0.as_float().unwrap().to_bits().hash(state);
+        } else {
+            state.write_usize(self.0.addr_as_usize());
+        }
+    }
+}
+
+impl PartialEq for TulispObjectEql {
+    fn eq(&self, other: &Self) -> bool {
+        self.0.eql(&other.0)
+    }
+}
+impl Eq for TulispObjectEql {}
+
+impl From<TulispObject> for TulispObjectEql {
+    fn from(obj: TulispObject) -> Self {
+        Self(obj)
+    }
+}
+
+pub(crate) fn add(ctx: &mut TulispContext) {
+    #[crate_fn(add_func = "ctx", name = "make-hash-table")]
+    fn make_hash_table() -> Rc<dyn Any> {
+        Rc::new(RefCell::new(HashMap::<TulispObjectEql, TulispObject>::new()))
+    }
+
+    #[crate_fn(add_func = "ctx", name = "gethash")]
+    fn gethash(key: TulispObject, table: TulispObject) -> Result<TulispObject, Error> {
+        let binding = table.as_any()?;
+        let table = binding
+            .downcast_ref::<RefCell<HashMap<TulispObjectEql, TulispObject>>>()
+            .unwrap();
+        let value = table
+            .borrow_mut()
+            .get(&key.into())
+            .cloned()
+            .unwrap_or(TulispObject::nil());
+
+        Ok(value)
+    }
+
+    #[crate_fn(add_func = "ctx", name = "puthash")]
+    fn puthash(
+        key: TulispObject,
+        value: TulispObject,
+        table: TulispObject,
+    ) -> Result<TulispObject, Error> {
+        let binding = table.as_any()?;
+        let table = binding
+            .downcast_ref::<RefCell<HashMap<TulispObjectEql, TulispObject>>>()
+            .unwrap();
+        table.borrow_mut().insert(key.into(), value);
+
+        Ok(TulispObject::nil())
+    }
+}

--- a/src/builtin/functions/mod.rs
+++ b/src/builtin/functions/mod.rs
@@ -58,6 +58,7 @@ mod comparison_of_numbers;
 mod conditionals;
 mod equality_predicates;
 mod functions;
+mod hash_table;
 mod list_elements;
 mod sequences;
 
@@ -67,6 +68,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
     conditionals::add(ctx);
     equality_predicates::add(ctx);
     functions::add(ctx);
+    hash_table::add(ctx);
     list_elements::add(ctx);
     sequences::add(ctx);
 }

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -116,6 +116,16 @@ Because there are a huge number of sequence functions that are not yet implement
 | `seq-subseq` | 🔳     |         |
 | `seq-let` | 🔳     |         |
 
+## Hash Tables
+
+Click [here](https://www.gnu.org/software/emacs/manual/html_node/elisp/Hash-Tables.html) for the Emacs lisp manual page for hash tables.
+
+| Name               | Status | Details |
+|--------------------|--------|---------|
+| `make-hash-table`  | ☑️     | takes no arguments, uses `eql` as the test function. |
+| `puthash`          | ☑️     |         |
+| `gethash`          | ☑️     |         |
+
 ## Others
 
 These functions need to be organized into categories.  They are grouped here for now.

--- a/src/object.rs
+++ b/src/object.rs
@@ -347,6 +347,10 @@ impl TulispObject {
         self.inner_ref().eq(&other.inner_ref())
     }
 
+    pub(crate) fn addr_as_usize(&self) -> usize {
+        self.rc.as_ptr() as usize
+    }
+
     pub(crate) fn clone_without_span(&self) -> Self {
         Self {
             rc: Rc::clone(&self.rc),

--- a/src/object.rs
+++ b/src/object.rs
@@ -117,6 +117,19 @@ impl TulispObject {
         self.eq_ptr(other)
     }
 
+    /// Returns true if `self` and `other` are the same object, or are
+    /// indistinguishable numbers.
+    ///
+    /// Read more about Emacs `eql`
+    /// [here](https://www.gnu.org/software/emacs/manual/html_node/elisp/Comparison-of-Numbers.html#index-eql)
+    pub fn eql(&self, other: &TulispObject) -> bool {
+        if self.numberp() {
+            self.eq_val(other)
+        } else {
+            self.eq_ptr(other)
+        }
+    }
+
     /// Returns an iterator over the values inside `self`.
     pub fn base_iter(&self) -> cons::BaseIter {
         self.rc.borrow().base_iter()

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1069,3 +1069,27 @@ fn test_macroexpand() -> Result<(), Error> {
 
     Ok(())
 }
+
+#[test]
+fn test_hash_table() -> Result<(), Error> {
+    tulisp_assert! {
+        program: r#"
+        (let ((tbl (make-hash-table)))
+          (puthash 'a 20 tbl)
+          (puthash 'b 30 tbl)
+          (gethash 'a tbl))
+        "#,
+        result: "20",
+    }
+    tulisp_assert! {
+        program: r#"
+        (let ((tbl (make-hash-table)))
+          (puthash 2 20 tbl)
+          (puthash 3 30 tbl)
+          (list (gethash 4 tbl) (gethash 2 tbl)))
+        "#,
+        result: "'(nil 20)",
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
The following methods are exposed:

- `make-hash-table`: takes no arguments, uses `eql` as the test
- `gethash`
- `puthash`