### PR TITLE
Expose `intern` through lisp

### DIFF
--- a/src/builtin/functions/functions.rs
+++ b/src/builtin/functions/functions.rs
@@ -98,6 +98,11 @@ pub(crate) fn add(ctx: &mut TulispContext) {
     }
 
     #[crate_fn(add_func = "ctx")]
+    fn intern(ctx: &mut TulispContext, name: String) -> Result<TulispObject, Error> {
+        Ok(ctx.intern(&name))
+    }
+
+    #[crate_fn(add_func = "ctx")]
     fn expt(base: TulispObject, pow: TulispObject) -> Result<TulispObject, Error> {
         Ok(f64::powf(base.try_into()?, pow.try_into()?).into())
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -547,11 +547,6 @@ fn test_lists() -> Result<(), Error> {
     }
 
     tulisp_assert! {
-        program: "(let ((vv '(12 20 30))) `(,(car vv) ,@(cdr vv) ,(cdr vv)))",
-        result: "'(12 20 30 (20 30))",
-    }
-
-    tulisp_assert! {
         program: "(consp '(20))",
         result: "t",
     }
@@ -621,6 +616,24 @@ fn test_lists() -> Result<(), Error> {
         program: r#"(mapcar (lambda (vv) (plist-get vv :age)) '((:name "person" :age 20) (:name "person2" :age 30)))"#,
         result: "'(20 30)",
     }
+    Ok(())
+}
+
+#[test]
+fn test_backquotes() -> Result<(), Error> {
+    tulisp_assert! {
+        program: "(let ((vv '(12 20 30))) `(,(car vv) ,@(cdr vv) ,(cdr vv)))",
+        result: "'(12 20 30 (20 30))",
+    }
+
+    tulisp_assert! {
+        program: r#"
+        (let ((a 10))
+          (eq 'a (cdr `(a . a))))
+        "#,
+        result: r#"t"#,
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
And fix a bug that was causing the deep-copying of interned symbols, creating non-interned copies.