### PR TITLE
Expose `TulispContext::eval_and_then`

### DIFF
--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -161,6 +161,7 @@ These functions need to be organized into categories.  They are grouped here for
 | `concat`                                                                                                | ☑️      | for strings                                       |
 | `expt`                                                                                                  | ☑️      |                                                   |
 | `load`                                                                                                  | ☑️      |                                                   |
+| `intern`                                                                                                | ☑️      | no optional obarray param, always uses default.   |
 
 ## Other predicates
 

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs};
 use crate::{
     builtin,
     error::Error,
-    eval::{eval, eval_basic, funcall, DummyEval},
+    eval::{eval, eval_and_then, eval_basic, funcall, DummyEval},
     list,
     parse::parse,
     TulispObject,
@@ -83,6 +83,16 @@ impl TulispContext {
     /// Evaluates the given value and returns the result.
     pub fn eval(&mut self, value: &TulispObject) -> Result<TulispObject, Error> {
         eval(self, value)
+    }
+
+    /// Evaluates the given value, run the given function on the result of the
+    /// evaluation, and returns the result of the function.
+    pub fn eval_and_then<T>(
+        &mut self,
+        expr: &TulispObject,
+        f: impl FnOnce(&TulispObject) -> Result<T, Error>,
+    ) -> Result<T, Error> {
+        eval_and_then(self, expr, f)
     }
 
     /// Calls the given function with the given arguments, and returns the

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -212,7 +212,7 @@ pub(crate) fn eval_check_null(ctx: &mut TulispContext, expr: &TulispObject) -> R
 pub(crate) fn eval_and_then<T>(
     ctx: &mut TulispContext,
     expr: &TulispObject,
-    func: fn(&TulispObject) -> Result<T, Error>,
+    func: impl FnOnce(&TulispObject) -> Result<T, Error>,
 ) -> Result<T, Error> {
     let mut result = None;
     eval_basic(ctx, expr, &mut result)?;

--- a/src/object.rs
+++ b/src/object.rs
@@ -582,7 +582,7 @@ macro_rules! extractor_cxr_and_then_fn {
         )]
         pub fn $name<Out: Default>(
             &self,
-            f: impl FnMut(&TulispObject) -> Result<Out, Error>,
+            f: impl FnOnce(&TulispObject) -> Result<Out, Error>,
         ) -> Result<Out, Error> {
             self.rc
                 .borrow()
@@ -594,7 +594,7 @@ macro_rules! extractor_cxr_and_then_fn {
         #[doc(hidden)]
         pub fn $name<Out: Default>(
             &self,
-            f: impl FnMut(&TulispObject) -> Result<Out, Error>,
+            f: impl FnOnce(&TulispObject) -> Result<Out, Error>,
         ) -> Result<Out, Error> {
             self.rc
                 .borrow()

--- a/src/value.rs
+++ b/src/value.rs
@@ -723,7 +723,7 @@ macro_rules! make_cxr_and_then {
     ($name:ident, $($step:tt)+) => {
         pub fn $name<Out: Default>(
             &self,
-            func: impl FnMut(&TulispObject) -> Result<Out, Error>,
+            func: impl FnOnce(&TulispObject) -> Result<Out, Error>,
         ) -> Result<Out, Error> {
             match self {
                 TulispValue::List { cons, .. } => cons.$($step)+(func),
@@ -789,7 +789,7 @@ impl TulispValue {
 
     pub fn car_and_then<Out: Default>(
         &self,
-        mut func: impl FnMut(&TulispObject) -> Result<Out, Error>,
+        func: impl FnOnce(&TulispObject) -> Result<Out, Error>,
     ) -> Result<Out, Error> {
         match self {
             TulispValue::List { cons, .. } => func(cons.car()),
@@ -803,7 +803,7 @@ impl TulispValue {
 
     pub fn cdr_and_then<Out: Default>(
         &self,
-        mut func: impl FnMut(&TulispObject) -> Result<Out, Error>,
+        func: impl FnOnce(&TulispObject) -> Result<Out, Error>,
     ) -> Result<Out, Error> {
         match self {
             TulispValue::List { cons, .. } => func(cons.cdr()),


### PR DESCRIPTION
Also update `cxr` and `cxr_and_then` methods to use the more lenient `FnOnce` signature.