### PR TITLE
Add support for backtraces

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,4 @@ name = "tulisp"
 path = "src/lib.rs"
 
 [dependencies]
-tulisp-proc-macros = "0.3.0"
+tulisp-proc-macros = "0.4.0"

--- a/src/builtin/functions/functions.rs
+++ b/src/builtin/functions/functions.rs
@@ -128,7 +128,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
     fn format(input: TulispObject, rest: TulispObject) -> Result<TulispObject, Error> {
         let mut args = rest.base_iter();
         let mut output = String::new();
-        let in_string = input.as_string().map_err(|e| e.with_span(input.span()))?;
+        let in_string = input.as_string().map_err(|e| e.with_trace(input.clone()))?;
         let mut in_chars = in_string.chars();
         while let Some(ch) = in_chars.next() {
             if ch != '%' {
@@ -160,8 +160,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     return Err(Error::new(
                         ErrorKind::SyntaxError,
                         format!("Invalid format operation: %{}", ch),
-                    )
-                    .with_span(input.span()))
+                    ))
                 }
             }
         }
@@ -204,16 +203,14 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                 return Err(Error::new(
                     ErrorKind::TypeMismatch,
                     "setq requires exactly 2 arguments".to_string(),
-                )
-                .with_span(args.span()));
+                ));
             }
             args.cdr_and_then(|x| {
                 if !x.null() {
                     return Err(Error::new(
                         ErrorKind::TypeMismatch,
                         "setq requires exactly 2 arguments".to_string(),
-                    )
-                    .with_span(x.span()));
+                    ));
                 }
                 args.car_and_then(|arg| ctx.eval(arg))
             })
@@ -240,21 +237,18 @@ pub(crate) fn add(ctx: &mut TulispContext) {
             if varitem.symbolp() {
                 local.set(varitem, TulispObject::nil())?;
             } else if varitem.consp() {
-                let span = varitem.span();
                 destruct_bind!((&optional name value &rest rest) = varitem);
                 if name.null() {
                     return Err(Error::new(
                         ErrorKind::Undefined,
                         "let varitem requires name".to_string(),
-                    )
-                    .with_span(span));
+                    ));
                 }
                 if !rest.null() {
                     return Err(Error::new(
                         ErrorKind::Undefined,
                         "let varitem has too many values".to_string(),
-                    )
-                    .with_span(span));
+                    ));
                 }
                 local.set(name, eval(ctx, &value)?)?;
             } else {
@@ -264,8 +258,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                         "varitems inside a let-varlist should be a var or a binding: {}",
                         varitem
                     ),
-                )
-                .with_span(varlist.span()));
+                ));
             };
         }
 
@@ -404,16 +397,14 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                 return Err(Error::new(
                     ErrorKind::TypeMismatch,
                     "cons requires exactly 2 arguments".to_string(),
-                )
-                .with_span(args.span()));
+                ));
             }
             args.cdr_and_then(|x| {
                 if !x.null() {
                     return Err(Error::new(
                         ErrorKind::TypeMismatch,
                         "cons requires exactly 2 arguments".to_string(),
-                    )
-                    .with_span(x.span()));
+                    ));
                 }
                 args.car_and_then(|arg| ctx.eval(arg))
             })

--- a/src/builtin/functions/numbers/arithmetic_operations.rs
+++ b/src/builtin/functions/numbers/arithmetic_operations.rs
@@ -26,8 +26,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
             Err(Error::new(
                 ErrorKind::MissingArgument,
                 "Call to `sub` without any arguments".to_string(),
-            )
-            .with_span(args.span()))
+            ))
         }
     }
     intern_set_func!(ctx, sub, "-");
@@ -64,8 +63,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
             _ => Err(Error::new(
                 ErrorKind::TypeMismatch,
                 "expected a number as argument.".to_string(),
-            )
-            .with_span(number.span())),
+            )),
         }
     }
 
@@ -77,8 +75,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
             _ => Err(Error::new(
                 ErrorKind::TypeMismatch,
                 "expected a number as argument.".to_string(),
-            )
-            .with_span(number.span())),
+            )),
         }
     }
 

--- a/src/builtin/functions/numbers/rounding_operations.rs
+++ b/src/builtin/functions/numbers/rounding_operations.rs
@@ -10,8 +10,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                 return Err(Error::new(
                     ErrorKind::TypeMismatch,
                     format!("Expected exatly 1 argument for fround. Got args: {}", args),
-                )
-                .with_span(args.span()));
+                ));
             }
             Ok(true) => {}
         }
@@ -23,8 +22,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     Err(Error::new(
                         ErrorKind::TypeMismatch,
                         format!("Expected float for fround. Got: {}", x),
-                    )
-                    .with_span(x.span()))
+                    ))
                 }
             })
         })

--- a/src/cons.rs
+++ b/src/cons.rs
@@ -188,7 +188,6 @@ impl<T: 'static + std::convert::TryFrom<TulispObject>> Iterator for Iter<T> {
                     ErrorKind::TypeMismatch,
                     format!("Iter<{}> can't handle {}", tid, vv),
                 )
-                .with_span(vv.span())
             })
         })
     }

--- a/src/lists.rs
+++ b/src/lists.rs
@@ -8,7 +8,7 @@ pub fn length(list: &TulispObject) -> Result<i64, Error> {
     list.base_iter()
         .count()
         .try_into()
-        .map_err(|e: _| Error::new(ErrorKind::OutOfRange, format!("{}", e)).with_span(list.span()))
+        .map_err(|e: _| Error::new(ErrorKind::OutOfRange, format!("{}", e)))
 }
 
 /// Returns the last link in the given list.
@@ -20,8 +20,7 @@ pub fn last(list: &TulispObject, n: Option<i64>) -> Result<TulispObject, Error> 
         return Err(Error::new(
             ErrorKind::TypeMismatch,
             format!("expected list, got: {}", list),
-        )
-        .with_span(list.span()));
+        ));
     }
 
     // TODO: emacs' implementation uses the `safe-length` function for this, but
@@ -33,8 +32,7 @@ pub fn last(list: &TulispObject, n: Option<i64>) -> Result<TulispObject, Error> 
             return Err(Error::new(
                 ErrorKind::OutOfRange,
                 format!("n must be positive. got: {}", n),
-            )
-            .with_span(list.span()));
+            ));
         }
         if n < len {
             return nthcdr(len - n, list.clone());
@@ -97,8 +95,7 @@ pub fn assoc(
         return Err(Error::new(
             ErrorKind::TypeMismatch,
             format!("expected alist. got: {}", alist),
-        )
-        .with_span(alist.span()));
+        ));
     }
     if let Some(testfn) = testfn {
         let pred = eval(ctx, &testfn)?;
@@ -145,8 +142,7 @@ fn assoc_find(
             return Err(Error::new(
                 ErrorKind::TypeMismatch,
                 "expected cons inside alist".to_owned(),
-            )
-            .with_span(kvpair.span()));
+            ));
         }
         if testfn(&kvpair.car()?, key)? {
             return Ok(kvpair);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -125,7 +125,7 @@ macro_rules! destruct_bind {
     (@reqr $vv:ident,) => {};
     (@no-rest $vv:ident) => {
         if !$vv.null() {
-            return Err(Error::new(ErrorKind::TypeMismatch,"Too many arguments".to_string(), ));
+            return Err(Error::new(ErrorKind::TypeMismatch,"Too many arguments".to_string()));
         }
     };
     (@rest $rest:ident $vv:ident) => {

--- a/src/object.rs
+++ b/src/object.rs
@@ -61,7 +61,7 @@ macro_rules! extractor_fn_with_err {
             self.rc
                 .borrow()
                 .$name()
-                .map_err(|e| e.with_span(self.span()))
+        .map_err(|e| e.with_trace(self.clone()))
         }
     };
 }
@@ -168,7 +168,7 @@ impl TulispObject {
             .borrow_mut()
             .push(val)
             .map(|_| self)
-            .map_err(|e| e.with_span(self.span()))
+            .map_err(|e| e.with_trace(self.clone()))
     }
 
     /// Attaches the other list to the end of self.  Returns an Error if `self`
@@ -178,7 +178,7 @@ impl TulispObject {
             .borrow_mut()
             .append(other_list)
             .map(|_| self)
-            .map_err(|e| e.with_span(self.span()))
+            .map_err(|e| e.with_trace(self.clone()))
     }
 
     /// Returns a string representation of `self`, similar to the Emacs Lisp
@@ -195,7 +195,7 @@ impl TulispObject {
         self.rc
             .borrow_mut()
             .set(to_set)
-            .map_err(|e| e.with_span(self.span()))
+            .map_err(|e| e.with_trace(self.clone()))
     }
 
     /// Sets a value to `self`, in the new scope, such that when it is `unset`,
@@ -206,7 +206,7 @@ impl TulispObject {
         self.rc
             .borrow_mut()
             .set_scope(to_set)
-            .map_err(|e| e.with_span(self.span()))
+            .map_err(|e| e.with_trace(self.clone()))
     }
 
     /// Unsets the value from the most recent scope.
@@ -216,7 +216,7 @@ impl TulispObject {
         self.rc
             .borrow_mut()
             .unset()
-            .map_err(|e| e.with_span(self.span()))
+            .map_err(|e| e.with_trace(self.clone()))
     }
 
     // extractors begin
@@ -438,11 +438,8 @@ impl TryFrom<TulispObject> for f64 {
     type Error = Error;
 
     fn try_from(value: TulispObject) -> Result<Self, Self::Error> {
-        value
-            .rc
-            .borrow()
-            .try_float()
-            .map_err(|e| e.with_span(value.span()))
+        let res = value.rc.borrow().try_float();
+        res.map_err(|e| e.with_trace(value))
     }
 }
 
@@ -450,11 +447,8 @@ impl TryFrom<TulispObject> for i64 {
     type Error = Error;
 
     fn try_from(value: TulispObject) -> Result<Self, Self::Error> {
-        value
-            .rc
-            .borrow()
-            .as_int()
-            .map_err(|e| e.with_span(value.span()))
+        let res = value.rc.borrow().as_int();
+        res.map_err(|e| e.with_trace(value))
     }
 }
 
@@ -466,7 +460,7 @@ impl TryFrom<&TulispObject> for f64 {
             .rc
             .borrow()
             .try_float()
-            .map_err(|e| e.with_span(value.span()))
+            .map_err(|e| e.with_trace(value.clone()))
     }
 }
 
@@ -478,7 +472,7 @@ impl TryFrom<&TulispObject> for i64 {
             .rc
             .borrow()
             .as_int()
-            .map_err(|e| e.with_span(value.span()))
+            .map_err(|e| e.with_trace(value.clone()))
     }
 }
 
@@ -486,7 +480,7 @@ impl TryFrom<TulispObject> for String {
     type Error = Error;
 
     fn try_from(value: TulispObject) -> Result<Self, Self::Error> {
-        value.as_string().map_err(|e| e.with_span(value.span()))
+        value.as_string().map_err(|e| e.with_trace(value))
     }
 }
 
@@ -500,7 +494,7 @@ impl TryFrom<TulispObject> for Rc<dyn Any> {
     type Error = Error;
 
     fn try_from(value: TulispObject) -> Result<Self, Self::Error> {
-        value.as_any().map_err(|e| e.with_span(value.span()))
+        value.as_any().map_err(|e| e.with_trace(value))
     }
 }
 
@@ -561,7 +555,7 @@ macro_rules! extractor_cxr_fn {
             self.rc
                 .borrow()
                 .$name()
-                .map_err(|e| e.with_span(self.span()))
+                .map_err(|e| e.with_trace(self.clone()))
         }
     };
     ($name: ident) => {
@@ -570,7 +564,7 @@ macro_rules! extractor_cxr_fn {
             self.rc
                 .borrow()
                 .$name()
-                .map_err(|e| e.with_span(self.span()))
+                .map_err(|e| e.with_trace(self.clone()))
         }
     };
 }
@@ -587,7 +581,7 @@ macro_rules! extractor_cxr_and_then_fn {
             self.rc
                 .borrow()
                 .$name(f)
-                .map_err(|e| e.with_span(self.span()))
+        .map_err(|e| e.with_trace(self.clone()))
         }
     };
     ($name: ident) => {
@@ -599,7 +593,7 @@ macro_rules! extractor_cxr_and_then_fn {
             self.rc
                 .borrow()
                 .$name::<Out>(f)
-                .map_err(|e| e.with_span(self.span()))
+        .map_err(|e| e.with_trace(self.clone()))
         }
     };
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -346,7 +346,7 @@ impl Parser<'_, '_> {
             let Some(token) = self.tokenizer.peek() else {
                 return Err(
                     Error::new(ErrorKind::ParsingError, "Unclosed list".to_string())
-                        .with_span(Some(start_span)),
+                        .with_trace(TulispObject::nil().with_span(Some(start_span))),
                 );
             };
             match token {
@@ -385,7 +385,7 @@ impl Parser<'_, '_> {
                     ErrorKind::ParsingError,
                     "Expected only one item in list after dot.".to_string(),
                 )
-                .with_span(next.span()));
+                .with_trace(next));
             }
             inner.append(next)?;
         }
@@ -416,7 +416,7 @@ impl Parser<'_, '_> {
                 ErrorKind::ParsingError,
                 "Unexpected closing parenthesis".to_string(),
             )
-            .with_span(Some(span))),
+            .with_trace(TulispObject::nil().with_span(Some(span)))),
             Token::SharpQuote { span } | Token::Quote { span } => {
                 let next = match self.parse_value()? {
                     Some(next) => next,
@@ -425,7 +425,7 @@ impl Parser<'_, '_> {
                             ErrorKind::ParsingError,
                             "Unexpected EOF".to_string(),
                         )
-                        .with_span(Some(span)))
+                        .with_trace(TulispObject::nil().with_span(Some(span))))
                     }
                 };
                 Ok(Some(
@@ -442,7 +442,7 @@ impl Parser<'_, '_> {
                             ErrorKind::ParsingError,
                             "Unexpected EOF".to_string(),
                         )
-                        .with_span(Some(span)))
+                        .with_trace(TulispObject::nil().with_span(Some(span))))
                     }
                 };
                 Ok(Some(
@@ -455,7 +455,7 @@ impl Parser<'_, '_> {
                 ErrorKind::ParsingError,
                 "Unexpected dot".to_string(),
             )
-            .with_span(Some(span))),
+            .with_trace(TulispObject::nil().with_span(Some(span)))),
             Token::Comma { span } => {
                 let next = match self.parse_value()? {
                     Some(next) => next,
@@ -464,7 +464,7 @@ impl Parser<'_, '_> {
                             ErrorKind::ParsingError,
                             "Unexpected EOF".to_string(),
                         )
-                        .with_span(Some(span)))
+                        .with_trace(TulispObject::nil().with_span(Some(span))))
                     }
                 };
                 Ok(Some(
@@ -481,7 +481,7 @@ impl Parser<'_, '_> {
                             ErrorKind::ParsingError,
                             "Unexpected EOF".to_string(),
                         )
-                        .with_span(Some(span)))
+                        .with_trace(TulispObject::nil().with_span(Some(span))))
                     }
                 };
                 Ok(Some(
@@ -531,7 +531,7 @@ impl Parser<'_, '_> {
                 ErrorKind::ParsingError,
                 format!("{:?} {}", err.kind, err.desc),
             )
-            .with_span(Some(err.span))),
+            .with_trace(TulispObject::nil().with_span(Some(err.span)))),
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -65,7 +65,10 @@ fn test_comparison_of_numbers() -> Result<(), Error> {
     tulisp_assert! { program: "(> 5.0 10.0)", result: "nil" }
     tulisp_assert! {
         program: "(let ((a 10)) (> a))",
-        error: "<eval_string>:1.15-1.20: ERR OutOfRange: gt requires at least 2 arguments"
+        error: r#"ERR OutOfRange: gt requires at least 2 arguments
+<eval_string>:1.15-1.20:  at (> a)
+<eval_string>:1.1-1.21:  at (let ((a 10)) (> a))
+"#
     }
 
     // Greater than or equal
@@ -80,7 +83,10 @@ fn test_comparison_of_numbers() -> Result<(), Error> {
     tulisp_assert! { program: "(>= 5.0 10.0)", result: "nil" }
     tulisp_assert! {
         program: "(let ((a 10)) (>= a))",
-        error: "<eval_string>:1.15-1.21: ERR OutOfRange: ge requires at least 2 arguments"
+        error: r#"ERR OutOfRange: ge requires at least 2 arguments
+<eval_string>:1.15-1.21:  at (>= a)
+<eval_string>:1.1-1.22:  at (let ((a 10)) (>= a))
+"#
     }
 
     // Less than
@@ -95,7 +101,10 @@ fn test_comparison_of_numbers() -> Result<(), Error> {
     tulisp_assert! { program: "(< 5.0 10.0)", result: "t" }
     tulisp_assert! {
         program: "(let ((a 10)) (< a))",
-        error: "<eval_string>:1.15-1.20: ERR OutOfRange: lt requires at least 2 arguments"
+        error: r#"ERR OutOfRange: lt requires at least 2 arguments
+<eval_string>:1.15-1.20:  at (< a)
+<eval_string>:1.1-1.21:  at (let ((a 10)) (< a))
+"#
     }
 
     // Less than or equal
@@ -110,7 +119,10 @@ fn test_comparison_of_numbers() -> Result<(), Error> {
     tulisp_assert! { program: "(<= 5.0 10.0)", result: "t" }
     tulisp_assert! {
         program: "(let ((a 10)) (<= a))",
-        error: "<eval_string>:1.15-1.21: ERR OutOfRange: le requires at least 2 arguments"
+        error: r#"ERR OutOfRange: le requires at least 2 arguments
+<eval_string>:1.15-1.21:  at (<= a)
+<eval_string>:1.1-1.22:  at (let ((a 10)) (<= a))
+"#
     }
 
     Ok(())
@@ -283,7 +295,9 @@ fn test_defun() -> Result<(), Error> {
     }
     tulisp_assert! {
         program: "(defun j (&rest x y) nil) (j)",
-        error: "<eval_string>:1.19-1.20: ERR TypeMismatch: Too many &rest parameters",
+        error: r#"ERR TypeMismatch: Too many &rest parameters
+<eval_string>:1.1-1.26:  at (defun j (&rest x y) nil)
+"#
     }
     tulisp_assert! {
         program: r##"(defun j (&rest x) x) (list (j) (j 10) (j 100 200))"##,
@@ -303,11 +317,15 @@ fn test_defun() -> Result<(), Error> {
         }
     tulisp_assert! {
         program: "(defun add (x y) (+ x y)) (add 10)",
-        error: "<eval_string>:1.27-1.35: ERR TypeMismatch: Too few arguments",
+        error: r#"ERR TypeMismatch: Too few arguments
+<eval_string>:1.27-1.35:  at (add 10)
+"#
     }
     tulisp_assert! {
         program: "(defun add (x y) (+ x y)) (add 10 20 30)",
-        error: "<eval_string>:1.38-1.40: ERR TypeMismatch: Too many arguments",
+        error: r#"ERR TypeMismatch: Too many arguments
+<eval_string>:1.27-1.41:  at (add 10 20 30)
+"#
     }
     tulisp_assert! {
         program: "(defmacro num ()  4) (macroexpand '(num))",
@@ -329,11 +347,15 @@ fn test_defun() -> Result<(), Error> {
     }
     tulisp_assert! {
         program: "(defmacro inc (var)  (list 'setq var (list '+ 1 var))) (let ((x 4)) (inc))",
-        error: "<eval_string>:1.69-1.74: ERR TypeMismatch: Too few arguments",
+        error: r#"ERR TypeMismatch: Too few arguments
+<eval_string>:1.69-1.74:  at (inc)
+"#
     }
     tulisp_assert! {
         program: "(defmacro inc (var)  (list 'setq var (list '+ 1 var))) (let ((x 4)) (inc 4 5))",
-        error: "<eval_string>:1.76-1.77: ERR TypeMismatch: Too many arguments",
+        error: r#"ERR TypeMismatch: Too many arguments
+<eval_string>:1.69-1.78:  at (inc 4 5)
+"#
     }
     tulisp_assert! {
         program: r##"
@@ -416,11 +438,17 @@ fn test_eval() -> Result<(), Error> {
     }
     tulisp_assert! {
         program: "(let ((y j) (j 10)) (funcall j))",
-        error: "<eval_string>:1.10-1.11: ERR TypeMismatch: Variable definition is void: j",
+        error: r#"ERR TypeMismatch: Variable definition is void: j
+<eval_string>:1.10-1.11:  at j
+<eval_string>:1.1-1.33:  at (let ((y j) (j 10)) (funcall j))
+"#
     }
     tulisp_assert! {
         program: "(let ((j 10)) (+ j j))(+ j j)",
-        error: "<eval_string>:1.26-1.27: ERR TypeMismatch: Variable definition is void: j",
+        error: r#"ERR TypeMismatch: Variable definition is void: j
+<eval_string>:1.26-1.27:  at j
+<eval_string>:1.23-1.30:  at (+ j j)
+"#
     }
     Ok(())
 }
@@ -429,7 +457,9 @@ fn test_eval() -> Result<(), Error> {
 fn test_strings() -> Result<(), Error> {
     tulisp_assert! {
         program: r##"(concat 'hello 'world)"##,
-        error: "<eval_string>:1.1-1.23: ERR TypeMismatch: Not a string: hello"
+        error: r#"ERR TypeMismatch: Not a string: hello
+<eval_string>:1.1-1.23:  at (concat 'hello 'world)
+"#
     }
     tulisp_assert! { program: r##"(concat "hello" " world")"##, result: r#""hello world""# }
     tulisp_assert! {
@@ -466,11 +496,15 @@ fn test_cons() -> Result<(), Error> {
     };
     tulisp_assert! {
         program: "(cons 1)",
-        error: "<eval_string>:1.1-1.9: ERR TypeMismatch: cons requires exactly 2 arguments",
+        error: r#"ERR TypeMismatch: cons requires exactly 2 arguments
+<eval_string>:1.1-1.9:  at (cons 1)
+"#
     };
     tulisp_assert! {
         program: "(cons 1 2 3)",
-        error: "<eval_string>:1.1-1.13: ERR TypeMismatch: cons requires exactly 2 arguments",
+        error: r#"ERR TypeMismatch: cons requires exactly 2 arguments
+<eval_string>:1.1-1.13:  at (cons 1 2 3)
+"#
     };
     Ok(())
 }
@@ -487,11 +521,15 @@ fn test_quote() -> Result<(), Error> {
     };
     tulisp_assert! {
         program: "(quote)",
-        error: "<eval_string>:1.1-1.8: ERR TypeMismatch: quote: expected one argument",
+        error: r#"ERR TypeMismatch: quote: expected one argument
+<eval_string>:1.1-1.8:  at (quote)
+"#
     };
     tulisp_assert! {
         program: "(quote 1 2)",
-        error: "<eval_string>:1.1-1.12: ERR TypeMismatch: quote: expected one argument",
+        error: r#"ERR TypeMismatch: quote: expected one argument
+<eval_string>:1.1-1.12:  at (quote 1 2)
+"#
     };
     Ok(())
 }
@@ -543,7 +581,11 @@ fn test_lists() -> Result<(), Error> {
         (setq items
               (append items '(10)))
         "#,
-        error: "<eval_string>:3.23-3.28: ERR TypeMismatch: Variable definition is void: items",
+        error: r#"ERR TypeMismatch: Variable definition is void: items
+<eval_string>:3.23-3.28:  at items
+<eval_string>:3.15-3.35:  at (append items '(10))
+<eval_string>:2.9-3.36:  at (setq items (append items '(10)))
+"#
     }
 
     tulisp_assert! {
@@ -641,7 +683,9 @@ fn test_backquotes() -> Result<(), Error> {
 fn test_math() -> Result<(), Error> {
     tulisp_assert! {
         program: "(/ 10 0)",
-        error: "<eval_string>:1.1-1.9: ERR Undefined: Division by zero",
+        error: r#"ERR Undefined: Division by zero
+<eval_string>:1.1-1.9:  at (/ 10 0)
+"#,
     }
     tulisp_assert! {
         program: "(/ 0 10)",
@@ -649,7 +693,10 @@ fn test_math() -> Result<(), Error> {
     }
     tulisp_assert! {
         program: "(let ((a 10) (b 0)) (/ a b))",
-        error: "<eval_string>:1.21-1.28: ERR Undefined: Division by zero",
+        error: r#"ERR Undefined: Division by zero
+<eval_string>:1.21-1.28:  at (/ a b)
+<eval_string>:1.1-1.29:  at (let ((a 10) (b 0)) (/ a b))
+"#,
     }
 
     tulisp_assert! { program: "(/ 24 2 2)",                result: "6"     }
@@ -696,15 +743,24 @@ fn test_let() -> Result<(), Error> {
               (jj 20))
           (append kk (+ vv jj 1)))
         "#,
-        error: "<eval_string>:4.19-4.21: ERR TypeMismatch: Variable definition is void: kk",
+        error: r#"ERR TypeMismatch: Variable definition is void: kk
+<eval_string>:4.19-4.21:  at kk
+<eval_string>:4.11-4.34:  at (append kk (+ vv jj 1))
+<eval_string>:2.9-4.35:  at (let ((vv (+ 55 1)) (jj 20)) (append kk ...
+"#
     }
     tulisp_assert! {
         program: "(let ((22 (+ 55 1)) (jj 20)) (+ vv jj 1))",
-        error: "<eval_string>:1.8-1.10: ERR TypeMismatch: Expected Symbol: Can't assign to 22",
+        error: r#"ERR TypeMismatch: Expected Symbol: Can't assign to 22
+<eval_string>:1.8-1.10:  at 22
+<eval_string>:1.1-1.42:  at (let ((22 (+ 55 1)) (jj 20)) (+ vv jj 1)...
+"#
     }
     tulisp_assert! {
         program: "(let (18 (vv (+ 55 1)) (jj 20)) (+ vv jj 1))",
-        error: "<eval_string>:1.6-1.32: ERR SyntaxError: varitems inside a let-varlist should be a var or a binding: 18",
+        error: r#"ERR SyntaxError: varitems inside a let-varlist should be a var or a binding: 18
+<eval_string>:1.1-1.45:  at (let (18 (vv (+ 55 1)) (jj 20)) (+ vv jj...
+"#
     }
 
     tulisp_assert! {
@@ -788,7 +844,10 @@ fn test_sort() -> Result<(), Error> {
     }
     tulisp_assert! {
         program: "(sort '(20 10 30 15 45) '<<)",
-        error: "<eval_string>:1.26-1.28: ERR TypeMismatch: Variable definition is void: <<",
+        error: r#"ERR TypeMismatch: Variable definition is void: <<
+<eval_string>:1.26-1.28:  at <<
+<eval_string>:1.1-1.29:  at (sort '(20 10 30 15 45) '<<)
+"#
     }
     tulisp_assert! {
         program: "(defun << (v1 v2) (> v1 v2)) (sort '(20 10 30 15 45) '<<)",
@@ -971,12 +1030,16 @@ fn test_typed_iter() -> Result<(), Error> {
     tulisp_assert! {
         ctx: ctx,
         program: "(add_ints_no_default 20)",
-        error: "<eval_string>:1.22-1.24: ERR TypeMismatch: In call to \"add_ints_no_default\", arg \"ints\" needs to be a list",
+        error: r#"ERR TypeMismatch: In call to "add_ints_no_default", arg "ints" needs to be a list
+<eval_string>:1.1-1.25:  at (add_ints_no_default 20)
+"#
     }
     tulisp_assert! {
         ctx: ctx,
         program: "(add_ints 20)",
-        error: "<eval_string>:1.11-1.13: ERR TypeMismatch: In call to \"add_ints\", arg \"ints\" needs to be a list",
+        error: r#"ERR TypeMismatch: In call to "add_ints", arg "ints" needs to be a list
+<eval_string>:1.1-1.14:  at (add_ints 20)
+"#
     }
     Ok(())
 }
@@ -1022,7 +1085,11 @@ fn test_any() -> Result<(), Error> {
     tulisp_assert! {
         ctx: ctx,
         program: "(get_int 55)",
-        error: "<eval_string>:1.10-1.12: ERR TypeMismatch: Expected Any(Rc<dyn Any>): 55",
+        error: r#"ERR TypeMismatch: Expected Any(Rc<dyn Any>): 55
+<eval_string>:1.10-1.12:  at 55
+<eval_string>:1.10-1.12:  at 55
+<eval_string>:1.1-1.13:  at (get_int 55)
+"#
     }
     Ok(())
 }
@@ -1040,7 +1107,10 @@ fn test_load() -> Result<(), Error> {
     tulisp_assert! {
         ctx: ctx,
         program: r#"(load "tests/bad-load.lisp")"#,
-        error: "tests/bad-load.lisp:1.9-1.10: ERR ParsingError: Unexpected closing parenthesis",
+        error: r#"ERR ParsingError: Unexpected closing parenthesis
+tests/bad-load.lisp:1.9-1.10:  at nil
+<eval_string>:1.1-1.29:  at (load "tests/bad-load.lisp")
+"#
     }
 
     Ok(())


### PR DESCRIPTION
This is done by updating the `Error` to hold a vector of objects to trace the evaluation path back.

Closes #34 