### PR TITLE
Support lexical binding

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ It is very easy to get started.  Here's an example:
 - Backquote/Unquote forms (for example `` `(answer . ,(+ 2 3)) ``)
 - Threading macros (`thread-first` and `thread-last`)
 - Methods for reading from alists and plists
-- Dynamic binding (lexical binding planned)
+- Lexical scopes and lexical binding
 - Tailcall Optimization
 - Proc macros for exposing rust functions to tulisp
 - Decl macros for

--- a/src/builtin/functions/functions.rs
+++ b/src/builtin/functions/functions.rs
@@ -503,26 +503,6 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         Ok(TulispObject::nil())
     }
 
-    fn quote(_ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
-        if !args.consp() {
-            return Err(Error::new(
-                ErrorKind::TypeMismatch,
-                "quote: expected one argument".to_string(),
-            ));
-        }
-        args.cdr_and_then(|cdr| {
-            if !cdr.null() {
-                return Err(Error::new(
-                    ErrorKind::TypeMismatch,
-                    "quote: expected one argument".to_string(),
-                ));
-            }
-            Ok(())
-        })?;
-        args.car()
-    }
-    intern_set_func!(ctx, quote);
-
     #[crate_fn(add_func = "ctx")]
     fn null(arg: TulispObject) -> bool {
         arg.null()

--- a/src/builtin/functions/functions.rs
+++ b/src/builtin/functions/functions.rs
@@ -9,6 +9,7 @@ use crate::eval::eval_check_null;
 use crate::eval::DummyEval;
 use crate::eval::Eval;
 use crate::lists;
+use crate::value::DefunParams;
 use crate::TulispObject;
 use crate::TulispValue;
 use crate::{destruct_bind, list};
@@ -370,11 +371,115 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         } else {
             rest
         };
-        Ok(TulispValue::Lambda {
-            params: params.try_into()?,
-            body,
+        let params: DefunParams = params.try_into()?;
+        let param_names: Vec<_> = params.iter().map(|x| x.param.clone()).collect();
+
+        fn capture_inside_quoted(
+            captured_vars: &mut Vec<(TulispObject, TulispObject)>,
+            exclude: &[TulispObject],
+            value: TulispObject,
+        ) -> Result<TulispObject, Error> {
+            let inner_ref = value.inner_ref();
+            let res = match &*inner_ref {
+                TulispValue::Backquote { value } => TulispValue::Backquote {
+                    value: capture_variables(captured_vars, exclude, value.clone())?,
+                }
+                .into_ref(value.span()),
+                TulispValue::Unquote { value } => TulispValue::Unquote {
+                    value: capture_variables(captured_vars, exclude, value.clone())?,
+                }
+                .into_ref(value.span()),
+                TulispValue::Splice { value } => TulispValue::Splice {
+                    value: capture_variables(captured_vars, exclude, value.clone())?,
+                }
+                .into_ref(value.span()),
+                TulispValue::Sharpquote { value } => TulispValue::Sharpquote {
+                    value: capture_variables(captured_vars, exclude, value.clone())?,
+                }
+                .into_ref(value.span()),
+                TulispValue::Quote { value } => TulispValue::Quote {
+                    value: capture_variables(captured_vars, exclude, value.clone())?,
+                }
+                .into_ref(value.span()),
+                _ => {
+                    drop(inner_ref);
+                    value
+                }
+            };
+            Ok(res)
         }
-        .into_ref(None))
+
+        fn slice_contains(vec: &[TulispObject], item: &TulispObject) -> bool {
+            for i in vec {
+                if i.eq(item) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        fn capture_symbol(
+            captured_vars: &mut Vec<(TulispObject, TulispObject)>,
+            exclude: &[TulispObject],
+            symbol: TulispObject,
+        ) -> Result<TulispObject, Error> {
+            if !symbol.is_lexically_bound() {
+                return Ok(symbol);
+            }
+            if !slice_contains(&exclude, &symbol) {
+                for (from, to) in captured_vars.iter() {
+                    if symbol.eq(from) {
+                        return Ok(to.clone().with_span(symbol.span()));
+                    }
+                }
+                let new_var = TulispObject::lexical_binding(symbol.clone());
+                new_var.set(symbol.get()?)?;
+                captured_vars.push((symbol, new_var.clone()));
+                return Ok(new_var);
+            }
+            return Ok(symbol);
+        }
+
+        fn capture_variables(
+            captured_vars: &mut Vec<(TulispObject, TulispObject)>,
+            exclude: &[TulispObject],
+            mut body: TulispObject,
+        ) -> Result<TulispObject, Error> {
+            let result = TulispObject::nil().with_span(body.span());
+            if !body.consp() {
+                if body.symbolp() {
+                    return Ok(capture_symbol(captured_vars, exclude, body)?);
+                }
+                return Ok(capture_inside_quoted(captured_vars, exclude, body)?);
+            }
+
+            loop {
+                let car = body.car()?;
+                if car.consp() {
+                    result.push(capture_variables(captured_vars, exclude, car)?)?;
+                } else if car.symbolp() {
+                    result.push(capture_symbol(captured_vars, exclude, car)?)?;
+                } else {
+                    result.push(capture_inside_quoted(captured_vars, exclude, car)?)?;
+                }
+                let cdr = body.cdr()?;
+                if cdr.null() {
+                    break;
+                }
+                if cdr.symbolp() {
+                    result.append(capture_symbol(captured_vars, exclude, cdr)?)?;
+                    break;
+                } else if !cdr.consp() {
+                    result.append(capture_inside_quoted(captured_vars, exclude, cdr)?)?;
+                    break;
+                }
+                body = cdr;
+            }
+            Ok(result)
+        }
+
+        let body = capture_variables(&mut vec![], &param_names, body)?;
+        Ok(TulispValue::Lambda { params, body }.into_ref(None))
     }
 
     #[crate_fn_no_eval(add_func = "ctx")]

--- a/src/builtin/functions/functions.rs
+++ b/src/builtin/functions/functions.rs
@@ -354,7 +354,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
             println!("mark_tail_calls error: {:?}", e);
             e
         })?;
-        name.set_scope(
+        name.set_global(
             TulispValue::Lambda {
                 params: params.try_into()?,
                 body,

--- a/src/builtin/functions/mod.rs
+++ b/src/builtin/functions/mod.rs
@@ -45,7 +45,7 @@ macro_rules! binary_ops {
 macro_rules! intern_set_func {
     ($ctx:ident, $func: ident, $name: expr) => {
         $ctx.intern($name)
-            .set_scope(TulispValue::Func(Rc::new($func)).into_ref(None))
+            .set_global(TulispValue::Func(Rc::new($func)).into_ref(None))
             .unwrap();
     };
     ($ctx:ident, $func: ident) => {

--- a/src/context.rs
+++ b/src/context.rs
@@ -87,7 +87,7 @@ impl TulispContext {
         func: impl Fn(&mut TulispContext, &TulispObject) -> Result<TulispObject, Error> + 'static,
     ) {
         self.intern(name)
-            .set_scope(TulispValue::Func(Rc::new(func)).into_ref(None))
+            .set_global(TulispValue::Func(Rc::new(func)).into_ref(None))
             .unwrap();
     }
 
@@ -98,7 +98,7 @@ impl TulispContext {
         func: impl Fn(&mut TulispContext, &TulispObject) -> Result<TulispObject, Error> + 'static,
     ) {
         self.intern(name)
-            .set_scope(TulispValue::Macro(Rc::new(func)).into_ref(None))
+            .set_global(TulispValue::Macro(Rc::new(func)).into_ref(None))
             .unwrap();
     }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -264,6 +264,9 @@ pub(crate) fn eval_basic<'a>(
             }
             *result = Some(value.get().map_err(|e| e.with_trace(expr.clone()))?);
         }
+        TulispValue::LexicalBinding { value, .. } => {
+            *result = Some(value.get().map_err(|e| e.with_trace(expr.clone()))?);
+        }
         TulispValue::Int { .. }
         | TulispValue::Float { .. }
         | TulispValue::String { .. }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -317,7 +317,7 @@ pub fn macroexpand(ctx: &mut TulispContext, inp: TulispObject) -> Result<TulispO
     };
     let mut x = match &*value.inner_ref() {
         TulispValue::Macro(func) => {
-            let expansion = func(ctx, &expr.cdr()?)?;
+            let expansion = func(ctx, &expr.cdr()?).map_err(|e| e.with_trace(inp))?;
             macroexpand(ctx, expansion)?
         }
         TulispValue::Defmacro { params, body } => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,7 +47,7 @@ It is very easy to get started.  Here's an example:
 - Backquote/Unquote forms (for example `` `(answer . ,(+ 2 3)) ``)
 - Threading macros (`thread-first` and `thread-last`)
 - Methods for reading from alists and plists
-- Dynamic binding (lexical binding planned)
+- Lexical scopes and lexical binding
 - Tailcall Optimization
 - Proc macros for exposing rust functions to tulisp
 - Decl macros for

--- a/src/object.rs
+++ b/src/object.rs
@@ -103,7 +103,7 @@ impl TulispObject {
     /// [here](https://www.gnu.org/software/emacs/manual/html_node/elisp/Equality-Predicates.html).
     pub fn equal(&self, other: &TulispObject) -> bool {
         if self.symbolp() {
-            self.eq_ptr(other)
+            self.eq(other)
         } else {
             self.eq_val(other)
         }
@@ -115,6 +115,8 @@ impl TulispObject {
     /// [here](https://www.gnu.org/software/emacs/manual/html_node/elisp/Equality-Predicates.html).
     pub fn eq(&self, other: &TulispObject) -> bool {
         self.eq_ptr(other)
+            || other.inner_ref().lex_symbol_eq(self)
+            || self.inner_ref().lex_symbol_eq(other)
     }
 
     /// Returns true if `self` and `other` are the same object, or are
@@ -341,6 +343,11 @@ impl TulispObject {
         TulispValue::symbol(name, constant).into_ref(None)
     }
 
+    pub(crate) fn lexical_binding(symbol: TulispObject) -> TulispObject {
+        let span = symbol.span();
+        TulispValue::lexical_binding(symbol).into_ref(span)
+    }
+
     pub(crate) fn new(vv: TulispValue, span: Option<Span>) -> TulispObject {
         Self {
             rc: Rc::new(RefCell::new(vv)),
@@ -355,6 +362,10 @@ impl TulispObject {
     /// done, and the symbol is known to be bound.
     pub(crate) fn set_unchecked(&self, to_set: TulispObject) {
         self.rc.borrow_mut().set_unchecked(to_set)
+    }
+
+    pub(crate) fn is_lexically_bound(&self) -> bool {
+        self.rc.borrow().is_lexically_bound()
     }
 
     pub(crate) fn eq_ptr(&self, other: &TulispObject) -> bool {

--- a/src/object.rs
+++ b/src/object.rs
@@ -364,6 +364,10 @@ impl TulispObject {
         self.rc.borrow_mut().set_unchecked(to_set)
     }
 
+    pub(crate) fn set_global(&self, to_set: TulispObject) -> Result<(), Error> {
+        self.rc.borrow_mut().set_global(to_set)
+    }
+
     pub(crate) fn is_lexically_bound(&self) -> bool {
         self.rc.borrow().is_lexically_bound()
     }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -390,9 +390,7 @@ impl Parser<'_, '_> {
             inner.append(next)?;
         }
 
-        if let Ok("defun" | "defmacro" | "lambda") =
-            inner.car()?.as_symbol().as_ref().map(|x| x.as_str())
-        {
+        if let Ok("defun" | "defmacro") = inner.car()?.as_symbol().as_ref().map(|x| x.as_str()) {
             inner = macroexpand(self.ctx, inner)?;
             eval(self.ctx, &inner)?;
             // recursively update ctx obj in case it is a recursive function.

--- a/src/value.rs
+++ b/src/value.rs
@@ -104,6 +104,7 @@ type TulispFn = dyn Fn(&mut TulispContext, &TulispObject) -> Result<TulispObject
 pub struct SymbolBindings {
     name: String,
     constant: bool,
+    has_global: bool,
     items: Vec<TulispObject>,
 }
 
@@ -116,6 +117,7 @@ impl SymbolBindings {
             ));
         }
         if self.items.is_empty() {
+            self.has_global = true;
             self.items.push(to_set);
         } else {
             *self.items.last_mut().unwrap() = to_set;
@@ -181,6 +183,10 @@ pub enum TulispValue {
     Symbol {
         value: SymbolBindings,
     },
+    LexicalBinding {
+        value: SymbolBindings,
+        symbol: TulispObject,
+    },
     Int {
         value: i64,
     },
@@ -232,6 +238,11 @@ impl std::fmt::Debug for TulispValue {
             Self::Symbol { value } => f
                 .debug_struct("Symbol")
                 .field("name", &value.name)
+                .field("value", value)
+                .finish(),
+            Self::LexicalBinding { value, symbol } => f
+                .debug_struct("LexicalBinding")
+                .field("symbol", symbol)
                 .field("value", value)
                 .finish(),
             Self::Int { value } => f.debug_struct("Int").field("value", value).finish(),
@@ -338,6 +349,7 @@ impl std::fmt::Display for TulispValue {
             TulispValue::Bounce => f.write_str("Bounce"),
             TulispValue::Nil { .. } => f.write_str("nil"),
             TulispValue::Symbol { value } => f.write_str(&value.name),
+            TulispValue::LexicalBinding { value, .. } => f.write_str(&value.name),
             TulispValue::Int { value, .. } => f.write_fmt(format_args!("{}", value)),
             TulispValue::Float { value, .. } => f.write_fmt(format_args!("{}", value)),
             TulispValue::String { value, .. } => f.write_fmt(format_args!(r#""{}""#, value)),
@@ -366,13 +378,28 @@ impl TulispValue {
             value: SymbolBindings {
                 name,
                 constant,
+                has_global: false,
+                items: Default::default(),
+            },
+        }
+    }
+
+    pub(crate) fn lexical_binding(symbol: TulispObject) -> TulispValue {
+        let name = symbol.to_string();
+        TulispValue::LexicalBinding {
+            symbol,
+            value: SymbolBindings {
+                name,
+                constant: false,
+                has_global: false,
                 items: Default::default(),
             },
         }
     }
 
     pub fn set(&mut self, to_set: TulispObject) -> Result<(), Error> {
-        if let TulispValue::Symbol { value, .. } = self {
+        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
+        {
             value.set(to_set)
         } else {
             Err(Error::new(
@@ -383,7 +410,8 @@ impl TulispValue {
     }
 
     pub fn set_scope(&mut self, to_set: TulispObject) -> Result<(), Error> {
-        if let TulispValue::Symbol { value, .. } = self {
+        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
+        {
             value.set_scope(to_set)
         } else {
             Err(Error::new(
@@ -399,13 +427,15 @@ impl TulispValue {
     /// For use in loops and other places where a set_scope has already been
     /// done, and the symbol is known to be bound.
     pub(crate) fn set_unchecked(&mut self, to_set: TulispObject) {
-        if let TulispValue::Symbol { value, .. } = self {
+        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
+        {
             value.set_unchecked(to_set)
         }
     }
 
     pub fn unset(&mut self) -> Result<(), Error> {
-        if let TulispValue::Symbol { value, .. } = self {
+        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
+        {
             value.unset()
         } else {
             Err(Error::new(
@@ -415,8 +445,36 @@ impl TulispValue {
         }
     }
 
+    pub(crate) fn is_lexically_bound(&self) -> bool {
+        match self {
+            TulispValue::Symbol { value } => {
+                if value.has_global && value.items.len() > 1 {
+                    true
+                } else if !value.has_global && !value.items.is_empty() {
+                    true
+                } else {
+                    false
+                }
+            }
+            TulispValue::LexicalBinding { .. } => true,
+            _ => false,
+        }
+    }
+
+    pub(crate) fn lex_symbol_eq(&self, other: &TulispObject) -> bool {
+        let TulispValue::LexicalBinding { symbol, .. } = self else {
+            return false;
+        };
+        if let TulispValue::LexicalBinding { symbol: other, .. } = &*other.inner_ref() {
+            symbol.eq(other)
+        } else {
+            symbol.eq(other)
+        }
+    }
+
     pub fn get(&self) -> Result<TulispObject, Error> {
-        if let TulispValue::Symbol { value, .. } = self {
+        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
+        {
             if value.is_constant() {
                 // Taking this path loses the span, so it should never be used.
                 // This check needs to be done in the object.
@@ -440,7 +498,8 @@ impl TulispValue {
     }
 
     pub fn boundp(&self) -> bool {
-        if let TulispValue::Symbol { value, .. } = self {
+        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
+        {
             value.boundp()
         } else {
             false
@@ -515,7 +574,9 @@ impl TulispValue {
 
     pub fn as_symbol(&self) -> Result<String, Error> {
         match self {
-            TulispValue::Symbol { value } => Ok(value.name.to_string()),
+            TulispValue::Symbol { value } | TulispValue::LexicalBinding { value, .. } => {
+                Ok(value.name.to_string())
+            }
             _ => Err(Error::new(
                 ErrorKind::TypeMismatch,
                 format!("Expected symbol: {}", self),
@@ -609,7 +670,10 @@ impl TulispValue {
     }
 
     pub fn symbolp(&self) -> bool {
-        matches!(self, TulispValue::Symbol { .. })
+        matches!(
+            self,
+            TulispValue::Symbol { .. } | TulispValue::LexicalBinding { .. }
+        )
     }
 
     pub fn as_string(&self) -> Result<String, Error> {

--- a/src/value.rs
+++ b/src/value.rs
@@ -125,6 +125,22 @@ impl SymbolBindings {
         Ok(())
     }
 
+    pub(crate) fn set_global(&mut self, to_set: TulispObject) -> Result<(), Error> {
+        if self.constant {
+            return Err(Error::new(
+                ErrorKind::Undefined,
+                format!("Can't set constant symbol: {}", self.name),
+            ));
+        }
+        self.has_global = true;
+        if self.items.is_empty() {
+            self.items.push(to_set);
+        } else {
+            *self.items.first_mut().unwrap() = to_set;
+        }
+        Ok(())
+    }
+
     pub fn set_scope(&mut self, to_set: TulispObject) -> Result<(), Error> {
         if self.constant {
             return Err(Error::new(
@@ -401,6 +417,18 @@ impl TulispValue {
         if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
         {
             value.set(to_set)
+        } else {
+            Err(Error::new(
+                ErrorKind::TypeMismatch,
+                "Can bind values only to Symbols".to_string(),
+            ))
+        }
+    }
+
+    pub(crate) fn set_global(&mut self, to_set: TulispObject) -> Result<(), Error> {
+        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
+        {
+            value.set_global(to_set)
         } else {
             Err(Error::new(
                 ErrorKind::TypeMismatch,


### PR DESCRIPTION
This is done by adding a new value type for a lexically bound symbol, that wraps a basic symbol.

Closes #52 