### PR TITLE
Replace internal `eval_basic` with Copy-on-Write `eval_cow` method

### DIFF
--- a/src/builtin/functions/conditionals.rs
+++ b/src/builtin/functions/conditionals.rs
@@ -1,6 +1,6 @@
 use crate::{
     builtin::functions::common::eval_2_arg_special_form,
-    eval::{eval_and_then, eval_basic},
+    eval::{eval_basic, eval_cow},
     list,
     lists::{last, length},
     Error, ErrorKind, TulispContext, TulispObject, TulispValue,
@@ -11,7 +11,7 @@ use tulisp_proc_macros::{crate_fn, crate_fn_no_eval};
 pub(crate) fn add(ctx: &mut TulispContext) {
     fn impl_if(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
         eval_2_arg_special_form(ctx, "if", args, true, |ctx, cond, then, else_body| {
-            if eval_and_then(ctx, cond, |x| Ok(x.is_truthy()))? {
+            if eval_cow(ctx, cond)?.is_truthy() {
                 ctx.eval(then)
             } else {
                 ctx.eval_progn(else_body)
@@ -39,7 +39,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
 
     fn cond(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
         for item in args.base_iter() {
-            if item.car_and_then(|x| eval_and_then(ctx, x, |x| Ok(x.is_truthy())))? {
+            if item.car_and_then(|x| Ok(eval_cow(ctx, x)?.is_truthy()))? {
                 return item.cdr_and_then(|x| ctx.eval_progn(x));
             }
         }

--- a/src/builtin/functions/functions.rs
+++ b/src/builtin/functions/functions.rs
@@ -3,8 +3,7 @@ use crate::context::Scope;
 use crate::context::TulispContext;
 use crate::error::Error;
 use crate::error::ErrorKind;
-use crate::eval::eval;
-use crate::eval::eval_and_then;
+use crate::eval::{eval, eval_cow};
 use crate::eval::eval_check_null;
 use crate::eval::DummyEval;
 use crate::eval::Eval;
@@ -278,7 +277,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                 args.car_and_then(|arg| ctx.eval(arg))
             })
         })?;
-        args.car_and_then(|name_sym| ctx.eval_and_then(name_sym, |name| name.set(value.clone())))?;
+        args.car_and_then(|name_sym| eval_cow(ctx, name_sym)?.set(value.clone()))?;
         Ok(value)
     }
     intern_set_func!(ctx, set);
@@ -671,7 +670,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     }
                     Ok(true) => {}
                 }
-                args.car_and_then(|arg| eval_and_then(ctx, &arg, |x| Ok(x.$name().into())))
+                args.car_and_then(|arg| Ok(eval_cow(ctx, &arg)?.$name().into()))
             }
             intern_set_func!(ctx, $name);
         };

--- a/src/builtin/functions/functions.rs
+++ b/src/builtin/functions/functions.rs
@@ -4,7 +4,6 @@ use crate::context::TulispContext;
 use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::eval::{eval, eval_cow};
-use crate::eval::eval_check_null;
 use crate::eval::DummyEval;
 use crate::eval::Eval;
 use crate::lists;
@@ -230,7 +229,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         rest: TulispObject,
     ) -> Result<TulispObject, Error> {
         let mut result = TulispObject::nil();
-        while !eval_check_null(ctx, &condition)? {
+        while !eval_cow(ctx, &condition)?.null() {
             result = ctx.eval_progn(&rest)?;
         }
         Ok(result)

--- a/src/builtin/functions/numbers/rounding_operations.rs
+++ b/src/builtin/functions/numbers/rounding_operations.rs
@@ -1,39 +1,37 @@
 use std::rc::Rc;
 
 use crate::{
-    builtin::functions::common::eval_1_arg_special_form, eval::eval_and_then, Error, ErrorKind,
+    builtin::functions::common::eval_1_arg_special_form, eval::eval_cow, Error, ErrorKind,
     TulispContext, TulispObject, TulispValue,
 };
 
 pub(crate) fn add(ctx: &mut TulispContext) {
     fn fround(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
         eval_1_arg_special_form(ctx, "fround", args, false, |ctx, arg1, _| {
-            eval_and_then(ctx, arg1, |x| {
-                if x.floatp() {
-                    Ok(f64::round(x.as_float().unwrap()).into())
-                } else {
-                    Err(Error::new(
-                        ErrorKind::TypeMismatch,
-                        format!("Expected float for fround. Got: {}", x),
-                    ))
-                }
-            })
+            let val = eval_cow(ctx, arg1)?;
+            if val.floatp() {
+                Ok(f64::round(val.as_float().unwrap()).into())
+            } else {
+                Err(Error::new(
+                    ErrorKind::TypeMismatch,
+                    format!("Expected float for fround. Got: {}", val),
+                ))
+            }
         })
     }
     intern_set_func!(ctx, fround);
 
     fn ftruncate(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
         eval_1_arg_special_form(ctx, "ftruncate", args, false, |ctx, arg1, _| {
-            eval_and_then(ctx, arg1, |x| {
-                if x.floatp() {
-                    Ok(f64::trunc(x.as_float().unwrap()).into())
-                } else {
-                    Err(Error::new(
-                        ErrorKind::TypeMismatch,
-                        format!("Expected float for ftruncate. Got: {}", x),
-                    ))
-                }
-            })
+            let val = eval_cow(ctx, arg1)?;
+            if val.floatp() {
+                Ok(f64::trunc(val.as_float().unwrap()).into())
+            } else {
+                Err(Error::new(
+                    ErrorKind::TypeMismatch,
+                    format!("Expected float for ftruncate. Got: {}", val),
+                ))
+            }
         })
     }
     intern_set_func!(ctx, ftruncate);

--- a/src/builtin/functions/sequences.rs
+++ b/src/builtin/functions/sequences.rs
@@ -67,16 +67,23 @@ pub(crate) fn add(ctx: &mut TulispContext) {
     ) -> Result<TulispObject, Error> {
         let pred = eval(ctx, &pred)?;
         let mut vec: Vec<_> = seq.base_iter().collect();
+        let mut err = None;
         vec.sort_by(|v1, v2| {
             if funcall::<DummyEval>(ctx, &pred, &list!(v1.clone(), v2.clone()).unwrap())
                 .map(|v| v.null())
-                .unwrap_or(false)
+                .unwrap_or_else(|x| {
+                    err = Some(x);
+                    false
+                })
             {
                 Ordering::Equal
             } else {
                 Ordering::Less
             }
         });
+        if let Some(err) = err {
+            return Err(err);
+        }
         let ret = vec
             .iter()
             .fold(list!(), |v1, v2| list!(,@v1 ,(*v2).clone()).unwrap());

--- a/src/builtin/functions/sequences.rs
+++ b/src/builtin/functions/sequences.rs
@@ -76,9 +76,9 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     false
                 })
             {
-                Ordering::Equal
-            } else {
                 Ordering::Less
+            } else {
+                Ordering::Greater
             }
         });
         if let Some(err) = err {
@@ -86,7 +86,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         }
         let ret = vec
             .iter()
-            .fold(list!(), |v1, v2| list!(,@v1 ,(*v2).clone()).unwrap());
+            .fold(TulispObject::nil(), |v1, v2| TulispObject::cons(v2.clone(), v1));
         Ok(ret)
     }
 }

--- a/src/cons.rs
+++ b/src/cons.rs
@@ -2,7 +2,7 @@ use std::marker::PhantomData;
 
 use crate::error::Error;
 use crate::error::ErrorKind;
-use crate::eval::eval_basic;
+use crate::eval::eval_cow;
 use crate::object::Span;
 use crate::TulispContext;
 use crate::TulispObject;
@@ -143,20 +143,12 @@ impl BaseIter {
     ) -> Option<Result<TulispObject, Error>> {
         if let Some(ref next) = self.next {
             let Cons { car, cdr } = next;
-            let new_car = {
-                let mut result = None;
-                if let Err(e) = eval_basic(ctx, car, &mut result) {
-                    return Some(Err(e));
-                };
-                if let Some(result) = result {
-                    Ok(result)
-                } else {
-                    Ok(next.car.clone())
-                }
+            let new_car = match eval_cow(ctx, car) {
+                Ok(vv) => vv.into_owned(),
+                Err(e) => return Some(Err(e)),
             };
-
             self.next = cdr.as_list_cons();
-            Some(new_car)
+            Some(Ok(new_car))
         } else {
             None
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs, rc::Rc};
 use crate::{
     builtin,
     error::Error,
-    eval::{eval, eval_basic, funcall, DummyEval},
+    eval::{eval, eval_cow, funcall, DummyEval},
     list,
     parse::parse,
     TulispObject, TulispValue,
@@ -171,10 +171,8 @@ impl TulispContext {
     /// last one.
     pub fn eval_progn(&mut self, seq: &TulispObject) -> Result<TulispObject, Error> {
         let mut ret = None;
-        let mut result = None;
         for val in seq.base_iter() {
-            eval_basic(self, &val, &mut result)?;
-            ret = Some(result.take().unwrap_or(val))
+            ret = Some(eval_cow(self, &val)?.into_owned())
         }
         Ok(ret.unwrap_or_else(TulispObject::nil))
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs, rc::Rc};
 use crate::{
     builtin,
     error::Error,
-    eval::{eval, eval_and_then, eval_basic, funcall, DummyEval},
+    eval::{eval, eval_basic, funcall, DummyEval},
     list,
     parse::parse,
     TulispObject, TulispValue,
@@ -105,16 +105,6 @@ impl TulispContext {
     /// Evaluates the given value and returns the result.
     pub fn eval(&mut self, value: &TulispObject) -> Result<TulispObject, Error> {
         eval(self, value)
-    }
-
-    /// Evaluates the given value, run the given function on the result of the
-    /// evaluation, and returns the result of the function.
-    pub fn eval_and_then<T>(
-        &mut self,
-        expr: &TulispObject,
-        f: impl FnOnce(&TulispObject) -> Result<T, Error>,
-    ) -> Result<T, Error> {
-        eval_and_then(self, expr, f)
     }
 
     /// Calls the given function with the given arguments, and returns the

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -231,20 +231,6 @@ pub(crate) fn eval_check_null(ctx: &mut TulispContext, expr: &TulispObject) -> R
     }
 }
 
-pub(crate) fn eval_and_then<T>(
-    ctx: &mut TulispContext,
-    expr: &TulispObject,
-    func: impl FnOnce(&TulispObject) -> Result<T, Error>,
-) -> Result<T, Error> {
-    let mut result = None;
-    eval_basic(ctx, expr, &mut result)?;
-    if let Some(result) = result {
-        func(&result)
-    } else {
-        func(expr)
-    }
-}
-
 // Eventually this should replace eval
 pub(crate) fn eval_cow<'a>(
     ctx: &mut TulispContext,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -235,7 +235,7 @@ pub(crate) fn eval_cow<'a>(
     }
 }
 
-pub(crate) fn eval_basic<'a>(
+fn eval_basic<'a>(
     ctx: &mut TulispContext,
     expr: &'a TulispObject,
     result: &'a mut Option<TulispObject>,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -217,32 +217,21 @@ pub(crate) fn eval_cow<'a>(
     ctx: &mut TulispContext,
     expr: &'a TulispObject,
 ) -> Result<Cow<'a, TulispObject>, Error> {
-    let mut result = None;
-    eval_basic(ctx, expr, &mut result)?;
-    if let Some(result) = result {
-        Ok(Cow::Owned(result))
-    } else {
-        Ok(Cow::Borrowed(expr))
-    }
-}
-
-fn eval_basic<'a>(
-    ctx: &mut TulispContext,
-    expr: &'a TulispObject,
-    result: &'a mut Option<TulispObject>,
-) -> Result<(), Error> {
     match &*expr.inner_ref() {
         TulispValue::List { .. } => {
-            *result = Some(eval_form::<Eval>(ctx, expr).map_err(|e| e.with_trace(expr.clone()))?);
+            return Ok(Cow::Owned(
+                eval_form::<Eval>(ctx, expr)
+                    .map_err(|e| e.with_trace(expr.clone()))?
+            ));
         }
         TulispValue::Symbol { value, .. } => {
             if value.is_constant() {
-                return Ok(());
+                return Ok(Cow::Borrowed(expr));
             }
-            *result = Some(value.get().map_err(|e| e.with_trace(expr.clone()))?);
+            return Ok(Cow::Owned(value.get().map_err(|e| e.with_trace(expr.clone()))?));
         }
         TulispValue::LexicalBinding { value, .. } => {
-            *result = Some(value.get().map_err(|e| e.with_trace(expr.clone()))?);
+            return Ok(Cow::Owned(value.get().map_err(|e| e.with_trace(expr.clone()))?));
         }
         TulispValue::Int { .. }
         | TulispValue::Float { .. }
@@ -254,13 +243,18 @@ fn eval_basic<'a>(
         | TulispValue::Any(_)
         | TulispValue::Bounce
         | TulispValue::Nil
-        | TulispValue::T => {}
-        TulispValue::Quote { value, .. } => {
-            *result = Some(value.clone());
+        | TulispValue::T => {
+            return Ok(Cow::Borrowed(expr));
+        }
+        TulispValue::Sharpquote { value }
+        | TulispValue::Quote { value } => {
+            return Ok(Cow::Owned(value.clone()));
         }
         TulispValue::Backquote { value } => {
-            *result =
-                Some(eval_back_quote(ctx, value.clone()).map_err(|e| e.with_trace(expr.clone()))?);
+            return Ok(Cow::Owned(
+                eval_back_quote(ctx, value.clone())
+                    .map_err(|e| e.with_trace(expr.clone()))?
+            ));
         }
         TulispValue::Unquote { .. } => {
             return Err(Error::new(
@@ -274,11 +268,7 @@ fn eval_basic<'a>(
                 "Splice without backquote".to_string(),
             ))
         }
-        TulispValue::Sharpquote { value, .. } => {
-            *result = Some(value.clone());
-        }
-    };
-    Ok(())
+    }
 }
 
 pub fn macroexpand(ctx: &mut TulispContext, inp: TulispObject) -> Result<TulispObject, Error> {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -221,16 +221,6 @@ pub(crate) fn eval(ctx: &mut TulispContext, expr: &TulispObject) -> Result<Tulis
     eval_cow(ctx, expr).map(|x| x.into_owned())
 }
 
-pub(crate) fn eval_check_null(ctx: &mut TulispContext, expr: &TulispObject) -> Result<bool, Error> {
-    let mut result = None;
-    eval_basic(ctx, expr, &mut result)?;
-    if let Some(result) = result {
-        Ok(result.null())
-    } else {
-        Ok(expr.null())
-    }
-}
-
 // Eventually this should replace eval
 pub(crate) fn eval_cow<'a>(
     ctx: &mut TulispContext,

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -934,10 +934,23 @@ fn test_sort() -> Result<(), Error> {
         result: "'(45 30 20 15 10)",
     }
     tulisp_assert! {
+        program: r#"(sort '("hello" "world") '>)"#,
+        error: r#"ERR TypeMismatch: Expected number, found: "world"
+<eval_string>:1.18-1.24:  at "world"
+<eval_string>:1.1-1.29:  at (sort '("hello" "world") '>)
+"#,
+    }
+    tulisp_assert! {
         program: "(sort '(20 10 30 15 45) '<<)",
         error: r#"ERR TypeMismatch: Variable definition is void: <<
 <eval_string>:1.26-1.28:  at <<
 <eval_string>:1.1-1.29:  at (sort '(20 10 30 15 45) '<<)
+"#
+    }
+    tulisp_assert! {
+        program: "(sort '(20 10 30 15 45))",
+        error: r#"ERR Undefined: function is void: nil
+<eval_string>:1.1-1.25:  at (sort '(20 10 30 15 45))
 "#
     }
     tulisp_assert! {


### PR DESCRIPTION
Also improve correctness of `sort` lisp function.