### PR TITLE
Remove the `eval_cow` method

### DIFF
--- a/src/builtin/functions/comparison_of_strings.rs
+++ b/src/builtin/functions/comparison_of_strings.rs
@@ -1,4 +1,4 @@
-use crate::{TulispContext, TulispObject, Error, ErrorKind, eval::eval_cow, destruct_bind, TulispValue};
+use crate::{TulispContext, TulispObject, Error, ErrorKind,  destruct_bind, TulispValue};
 
 fn string_cmp(
     ctx: &mut TulispContext,
@@ -6,8 +6,8 @@ fn string_cmp(
     oper: impl Fn(&str, &str) -> bool,
 ) -> Result<TulispObject, Error> {
     destruct_bind!((arg1 arg2) = args);
-    let string1 = eval_cow(ctx, &arg1)?;
-    let string2 = eval_cow(ctx, &arg2)?;
+    let string1 = ctx.eval(&arg1)?;
+    let string2 = ctx.eval(&arg2)?;
     let string1 = string1.inner_ref();
     let string2 = string2.inner_ref();
     match (&*string1, &*string2) {

--- a/src/builtin/functions/conditionals.rs
+++ b/src/builtin/functions/conditionals.rs
@@ -1,6 +1,6 @@
 use crate::{
     builtin::functions::common::eval_2_arg_special_form,
-    eval::{eval_basic, eval_cow},
+    eval::{eval_and_then, eval_basic},
     list,
     lists::{last, length},
     Error, ErrorKind, TulispContext, TulispObject, TulispValue,
@@ -11,7 +11,7 @@ use tulisp_proc_macros::{crate_fn, crate_fn_no_eval};
 pub(crate) fn add(ctx: &mut TulispContext) {
     fn impl_if(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
         eval_2_arg_special_form(ctx, "if", args, true, |ctx, cond, then, else_body| {
-            if eval_cow(ctx, cond)?.is_truthy() {
+            if eval_and_then(ctx, cond, |x| Ok(x.is_truthy()))? {
                 ctx.eval(then)
             } else {
                 ctx.eval_progn(else_body)
@@ -39,7 +39,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
 
     fn cond(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
         for item in args.base_iter() {
-            if item.car_and_then(|x| Ok(eval_cow(ctx, x)?.is_truthy()))? {
+            if item.car_and_then(|x| eval_and_then(ctx, x, |x| Ok(x.is_truthy())))? {
                 return item.cdr_and_then(|x| ctx.eval_progn(x));
             }
         }

--- a/src/builtin/functions/conditionals.rs
+++ b/src/builtin/functions/conditionals.rs
@@ -1,6 +1,6 @@
 use crate::{
     builtin::functions::common::eval_2_arg_special_form,
-    eval::eval_cow,
+    eval::{eval_basic, eval_cow},
     list,
     lists::{last, length},
     Error, ErrorKind, TulispContext, TulispObject, TulispValue,
@@ -57,11 +57,19 @@ pub(crate) fn add(ctx: &mut TulispContext) {
     fn and(ctx: &mut TulispContext, rest: TulispObject) -> Result<TulispObject, Error> {
         let mut ret = TulispObject::nil();
         for item in rest.base_iter() {
-            let result = eval_cow(ctx, &item)?;
-            if result.null() {
-                return Ok(result.into_owned());
+            let mut result = None;
+            eval_basic(ctx, &item, &mut result)?;
+            if let Some(result) = result {
+                if result.null() {
+                    return Ok(result);
+                }
+                ret = result;
+            } else {
+                if item.null() {
+                    return Ok(item);
+                }
+                ret = item;
             }
-            ret = result.into_owned();
         }
         Ok(ret)
     }
@@ -69,9 +77,14 @@ pub(crate) fn add(ctx: &mut TulispContext) {
     #[crate_fn_no_eval(add_func = "ctx")]
     fn or(ctx: &mut TulispContext, rest: TulispObject) -> Result<TulispObject, Error> {
         for item in rest.base_iter() {
-            let result = eval_cow(ctx, &item)?;
-            if !result.null() {
-                return Ok(result.into_owned());
+            let mut result = None;
+            eval_basic(ctx, &item, &mut result)?;
+            if let Some(result) = result {
+                if !result.null() {
+                    return Ok(result);
+                }
+            } else if !item.null() {
+                return Ok(item);
             }
         }
         Ok(TulispObject::nil())

--- a/src/builtin/functions/functions.rs
+++ b/src/builtin/functions/functions.rs
@@ -4,6 +4,7 @@ use crate::context::TulispContext;
 use crate::error::Error;
 use crate::error::ErrorKind;
 use crate::eval::{eval, eval_cow};
+use crate::eval::eval_check_null;
 use crate::eval::DummyEval;
 use crate::eval::Eval;
 use crate::lists;
@@ -229,7 +230,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         rest: TulispObject,
     ) -> Result<TulispObject, Error> {
         let mut result = TulispObject::nil();
-        while !eval_cow(ctx, &condition)?.null() {
+        while !eval_check_null(ctx, &condition)? {
             result = ctx.eval_progn(&rest)?;
         }
         Ok(result)

--- a/src/builtin/functions/functions.rs
+++ b/src/builtin/functions/functions.rs
@@ -3,7 +3,8 @@ use crate::context::Scope;
 use crate::context::TulispContext;
 use crate::error::Error;
 use crate::error::ErrorKind;
-use crate::eval::{eval, eval_cow};
+use crate::eval::eval;
+use crate::eval::eval_and_then;
 use crate::eval::eval_check_null;
 use crate::eval::DummyEval;
 use crate::eval::Eval;
@@ -277,7 +278,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                 args.car_and_then(|arg| ctx.eval(arg))
             })
         })?;
-        args.car_and_then(|name_sym| eval_cow(ctx, name_sym)?.set(value.clone()))?;
+        args.car_and_then(|name_sym| ctx.eval_and_then(name_sym, |name| name.set(value.clone())))?;
         Ok(value)
     }
     intern_set_func!(ctx, set);
@@ -670,7 +671,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     }
                     Ok(true) => {}
                 }
-                args.car_and_then(|arg| Ok(eval_cow(ctx, &arg)?.$name().into()))
+                args.car_and_then(|arg| eval_and_then(ctx, &arg, |x| Ok(x.$name().into())))
             }
             intern_set_func!(ctx, $name);
         };

--- a/src/builtin/functions/numbers/rounding_operations.rs
+++ b/src/builtin/functions/numbers/rounding_operations.rs
@@ -1,37 +1,39 @@
 use std::rc::Rc;
 
 use crate::{
-    builtin::functions::common::eval_1_arg_special_form, eval::eval_cow, Error, ErrorKind,
+    builtin::functions::common::eval_1_arg_special_form, eval::eval_and_then, Error, ErrorKind,
     TulispContext, TulispObject, TulispValue,
 };
 
 pub(crate) fn add(ctx: &mut TulispContext) {
     fn fround(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
         eval_1_arg_special_form(ctx, "fround", args, false, |ctx, arg1, _| {
-            let val = eval_cow(ctx, arg1)?;
-            if val.floatp() {
-                Ok(f64::round(val.as_float().unwrap()).into())
-            } else {
-                Err(Error::new(
-                    ErrorKind::TypeMismatch,
-                    format!("Expected float for fround. Got: {}", val),
-                ))
-            }
+            eval_and_then(ctx, arg1, |x| {
+                if x.floatp() {
+                    Ok(f64::round(x.as_float().unwrap()).into())
+                } else {
+                    Err(Error::new(
+                        ErrorKind::TypeMismatch,
+                        format!("Expected float for fround. Got: {}", x),
+                    ))
+                }
+            })
         })
     }
     intern_set_func!(ctx, fround);
 
     fn ftruncate(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
         eval_1_arg_special_form(ctx, "ftruncate", args, false, |ctx, arg1, _| {
-            let val = eval_cow(ctx, arg1)?;
-            if val.floatp() {
-                Ok(f64::trunc(val.as_float().unwrap()).into())
-            } else {
-                Err(Error::new(
-                    ErrorKind::TypeMismatch,
-                    format!("Expected float for ftruncate. Got: {}", val),
-                ))
-            }
+            eval_and_then(ctx, arg1, |x| {
+                if x.floatp() {
+                    Ok(f64::trunc(x.as_float().unwrap()).into())
+                } else {
+                    Err(Error::new(
+                        ErrorKind::TypeMismatch,
+                        format!("Expected float for ftruncate. Got: {}", x),
+                    ))
+                }
+            })
         })
     }
     intern_set_func!(ctx, ftruncate);

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs, rc::Rc};
 use crate::{
     builtin,
     error::Error,
-    eval::{eval, eval_basic, funcall, DummyEval},
+    eval::{eval, eval_and_then, eval_basic, funcall, DummyEval},
     list,
     parse::parse,
     TulispObject, TulispValue,
@@ -105,6 +105,16 @@ impl TulispContext {
     /// Evaluates the given value and returns the result.
     pub fn eval(&mut self, value: &TulispObject) -> Result<TulispObject, Error> {
         eval(self, value)
+    }
+
+    /// Evaluates the given value, run the given function on the result of the
+    /// evaluation, and returns the result of the function.
+    pub fn eval_and_then<T>(
+        &mut self,
+        expr: &TulispObject,
+        f: impl FnOnce(&TulispObject) -> Result<T, Error>,
+    ) -> Result<T, Error> {
+        eval_and_then(self, expr, f)
     }
 
     /// Calls the given function with the given arguments, and returns the

--- a/src/context.rs
+++ b/src/context.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, fs, rc::Rc};
 use crate::{
     builtin,
     error::Error,
-    eval::{eval, eval_cow, funcall, DummyEval},
+    eval::{eval, eval_basic, funcall, DummyEval},
     list,
     parse::parse,
     TulispObject, TulispValue,
@@ -171,8 +171,10 @@ impl TulispContext {
     /// last one.
     pub fn eval_progn(&mut self, seq: &TulispObject) -> Result<TulispObject, Error> {
         let mut ret = None;
+        let mut result = None;
         for val in seq.base_iter() {
-            ret = Some(eval_cow(self, &val)?.into_owned())
+            eval_basic(self, &val, &mut result)?;
+            ret = Some(result.take().unwrap_or(val))
         }
         Ok(ret.unwrap_or_else(TulispObject::nil))
     }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -221,6 +221,16 @@ pub(crate) fn eval(ctx: &mut TulispContext, expr: &TulispObject) -> Result<Tulis
     eval_cow(ctx, expr).map(|x| x.into_owned())
 }
 
+pub(crate) fn eval_check_null(ctx: &mut TulispContext, expr: &TulispObject) -> Result<bool, Error> {
+    let mut result = None;
+    eval_basic(ctx, expr, &mut result)?;
+    if let Some(result) = result {
+        Ok(result.null())
+    } else {
+        Ok(expr.null())
+    }
+}
+
 // Eventually this should replace eval
 pub(crate) fn eval_cow<'a>(
     ctx: &mut TulispContext,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -12,7 +12,8 @@ pub(crate) trait Evaluator {
     fn eval(
         ctx: &mut TulispContext,
         value: &TulispObject,
-    ) -> Result<TulispObject, Error>;
+        result: &mut Option<TulispObject>,
+    ) -> Result<(), Error>;
 }
 
 pub(crate) struct Eval;
@@ -20,8 +21,9 @@ impl Evaluator for Eval {
     fn eval(
         ctx: &mut TulispContext,
         value: &TulispObject,
-    ) -> Result<TulispObject, Error> {
-        eval(ctx, value)
+        result: &mut Option<TulispObject>,
+    ) -> Result<(), Error> {
+        eval_basic(ctx, value, result)
     }
 }
 
@@ -30,8 +32,9 @@ impl Evaluator for DummyEval {
     fn eval(
         _ctx: &mut TulispContext,
         _value: &TulispObject,
-    ) -> Result<TulispObject, Error> {
-        Ok(_value.to_owned())
+        _result: &mut Option<TulispObject>,
+    ) -> Result<(), Error> {
+        Ok(())
     }
 }
 
@@ -41,20 +44,26 @@ fn zip_function_args<E: Evaluator>(
     args: &TulispObject,
 ) -> Result<(), Error> {
     let mut args_iter = args.base_iter();
+    let mut eval_result = None;
     for param in params.iter() {
         let val = if param.is_optional {
             match args_iter.next() {
-                Some(vv) => E::eval(ctx, &vv)?,
+                Some(vv) => {
+                    E::eval(ctx, &vv, &mut eval_result)?;
+                    eval_result.take().unwrap_or(vv)
+                }
                 None => TulispObject::nil(),
             }
         } else if param.is_rest {
             let ret = TulispObject::nil();
             for arg in args_iter.by_ref() {
-                ret.push(E::eval(ctx, &arg)?)?;
+                E::eval(ctx, &arg, &mut eval_result)?;
+                ret.push(eval_result.take().unwrap_or(arg))?;
             }
             ret
         } else if let Some(vv) = args_iter.next() {
-            E::eval(ctx, &vv)?
+            E::eval(ctx, &vv, &mut eval_result)?;
+            eval_result.take().unwrap_or(vv)
         } else {
             return Err(Error::new(
                 ErrorKind::TypeMismatch,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -231,6 +231,20 @@ pub(crate) fn eval_check_null(ctx: &mut TulispContext, expr: &TulispObject) -> R
     }
 }
 
+pub(crate) fn eval_and_then<T>(
+    ctx: &mut TulispContext,
+    expr: &TulispObject,
+    func: impl FnOnce(&TulispObject) -> Result<T, Error>,
+) -> Result<T, Error> {
+    let mut result = None;
+    eval_basic(ctx, expr, &mut result)?;
+    if let Some(result) = result {
+        func(&result)
+    } else {
+        func(expr)
+    }
+}
+
 // Eventually this should replace eval
 pub(crate) fn eval_cow<'a>(
     ctx: &mut TulispContext,

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -1,5 +1,3 @@
-use std::borrow::Cow;
-
 use crate::{
     context::TulispContext,
     error::{Error, ErrorKind},
@@ -218,7 +216,13 @@ fn eval_back_quote(ctx: &mut TulispContext, mut vv: TulispObject) -> Result<Tuli
 }
 
 pub(crate) fn eval(ctx: &mut TulispContext, expr: &TulispObject) -> Result<TulispObject, Error> {
-    eval_cow(ctx, expr).map(|x| x.into_owned())
+    let mut result = None;
+    eval_basic(ctx, expr, &mut result)?;
+    if let Some(result) = result {
+        Ok(result)
+    } else {
+        Ok(expr.clone())
+    }
 }
 
 pub(crate) fn eval_check_null(ctx: &mut TulispContext, expr: &TulispObject) -> Result<bool, Error> {
@@ -242,20 +246,6 @@ pub(crate) fn eval_and_then<T>(
         func(&result)
     } else {
         func(expr)
-    }
-}
-
-// Eventually this should replace eval
-pub(crate) fn eval_cow<'a>(
-    ctx: &mut TulispContext,
-    expr: &'a TulispObject,
-) -> Result<Cow<'a, TulispObject>, Error> {
-    let mut result = None;
-    eval_basic(ctx, expr, &mut result)?;
-    if let Some(result) = result {
-        Ok(Cow::Owned(result))
-    } else {
-        Ok(Cow::Borrowed(expr))
     }
 }
 

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -235,7 +235,7 @@ pub(crate) fn eval_cow<'a>(
     }
 }
 
-fn eval_basic<'a>(
+pub(crate) fn eval_basic<'a>(
     ctx: &mut TulispContext,
     expr: &'a TulispObject,
     result: &'a mut Option<TulispObject>,


### PR DESCRIPTION
The addition of the cow types caused slight slowdowns because of the additional allocation, and not enough gain, because only the top level objects could be borrowed.