### PR TITLE
System time tracking methods

### DIFF
--- a/src/builtin/functions/mod.rs
+++ b/src/builtin/functions/mod.rs
@@ -62,6 +62,7 @@ mod hash_table;
 mod list_elements;
 mod numbers;
 mod sequences;
+mod time_operations;
 
 pub(crate) fn add(ctx: &mut TulispContext) {
     conditionals::add(ctx);
@@ -72,4 +73,5 @@ pub(crate) fn add(ctx: &mut TulispContext) {
     sequences::add(ctx);
     numbers::add(ctx);
     comparison_of_strings::add(ctx);
+    time_operations::add(ctx);
 }

--- a/src/builtin/functions/time_operations.rs
+++ b/src/builtin/functions/time_operations.rs
@@ -1,0 +1,330 @@
+use tulisp_proc_macros::crate_fn;
+
+use crate::{Error, ErrorKind, TulispContext, TulispObject};
+
+pub(crate) fn add(ctx: &mut TulispContext) {
+    #[crate_fn(add_func = "ctx", name = "current-time")]
+    fn current_time() -> TulispObject {
+        let usec_since_epoch = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as i64;
+        return TulispObject::cons(usec_since_epoch.into(), 1_000_000_000.into());
+    }
+
+    #[crate_fn(add_func = "ctx", name = "time-less-p")]
+    fn time_less_p(t1: TulispObject, t2: TulispObject) -> Result<TulispObject, Error> {
+        time_operation(t1, t2, |a, b, _| (a < b).into())
+    }
+
+    #[crate_fn(add_func = "ctx", name = "time-equal-p")]
+    fn time_equal_p(t1: TulispObject, t2: TulispObject) -> Result<TulispObject, Error> {
+        time_operation(t1, t2, |a, b, _| (a == b).into())
+    }
+
+    #[crate_fn(add_func = "ctx", name = "time-subtract")]
+    fn time_subtract(t1: TulispObject, t2: TulispObject) -> Result<TulispObject, Error> {
+        time_operation(t1, t2, |a, b, hz| {
+            TulispObject::cons((a - b).into(), hz.into())
+        })
+    }
+
+    #[crate_fn(add_func = "ctx", name = "time-add")]
+    fn time_add(t1: TulispObject, t2: TulispObject) -> Result<TulispObject, Error> {
+        time_operation(t1, t2, |a, b, hz| {
+            TulispObject::cons((a + b).into(), hz.into())
+        })
+    }
+
+    fn time_operation(
+        t1: TulispObject,
+        t2: TulispObject,
+        op: impl Fn(i64, i64, i64) -> TulispObject,
+    ) -> Result<TulispObject, Error> {
+        let (ticks1, hz1) = if t1.integerp() {
+            if let Ok(ticks1) = t1.as_int() {
+                (ticks1, 1)
+            } else {
+                return Err(
+                    Error::new(ErrorKind::TypeMismatch, "expected integer".to_string())
+                        .with_trace(t1),
+                );
+            }
+        } else if let Some(cons) = t1.as_list_cons() {
+            if let (Ok(ticks1), Ok(hz1)) = (cons.car().as_int(), cons.cdr().as_int()) {
+                (ticks1, hz1)
+            } else {
+                return Err(Error::new(
+                    ErrorKind::TypeMismatch,
+                    "expected (ticks . hz) pair".to_string(),
+                )
+                .with_trace(t1));
+            }
+        } else {
+            return Err(Error::new(
+                ErrorKind::TypeMismatch,
+                "expected integer or (ticks . hz) pair".to_string(),
+            )
+            .with_trace(t1));
+        };
+
+        let (ticks2, hz2) = if t2.integerp() {
+            if let Ok(ticks2) = t2.as_int() {
+                (ticks2, 1)
+            } else {
+                return Err(
+                    Error::new(ErrorKind::TypeMismatch, "expected integer".to_string())
+                        .with_trace(t2),
+                );
+            }
+        } else if let Some(cons) = t2.as_list_cons() {
+            if let (Ok(ticks2), Ok(hz2)) = (cons.car().as_int(), cons.cdr().as_int()) {
+                (ticks2, hz2)
+            } else {
+                return Err(Error::new(
+                    ErrorKind::TypeMismatch,
+                    "expected (ticks . hz) pair".to_string(),
+                )
+                .with_trace(t2));
+            }
+        } else {
+            return Err(Error::new(
+                ErrorKind::TypeMismatch,
+                "expected integer or (ticks . hz) pair".to_string(),
+            )
+            .with_trace(t2));
+        };
+
+        if hz1 == hz2 {
+            return Ok(op(ticks1, ticks2, hz1));
+        } else if hz1 > hz2 {
+            let factor = hz1 / hz2;
+            return Ok(op(ticks1, ticks2 * factor, hz1));
+        } else {
+            let factor = hz2 / hz1;
+            return Ok(op(ticks1 * factor, ticks2, hz2));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        Error, TulispContext,
+        test_utils::{eval_assert, eval_assert_equal, eval_assert_not},
+    };
+
+    #[test]
+    fn test_current_time() -> Result<(), Error> {
+        let mut ctx = TulispContext::new();
+        super::add(&mut ctx);
+
+        let t1 = ctx.eval_string("(current-time)").unwrap();
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos() as i64;
+
+        let now_minus_10ms = now - 10_000_000;
+
+        assert!(t1.car()?.as_int()? <= now);
+        assert!(t1.car()?.as_int()? > now_minus_10ms);
+
+        assert_eq!(t1.cdr()?.as_int()?, 1_000_000_000);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_time_less_p() -> Result<(), Error> {
+        let ctx = &mut TulispContext::new();
+
+        super::add(ctx);
+
+        let t1 = ctx.eval_string("(current-time)").unwrap();
+        let t2 = ctx.eval_string("(current-time)").unwrap();
+
+        eval_assert(ctx, &format!("(time-less-p '{} '{})", t1, t2));
+
+        eval_assert_not(ctx, &format!("(time-less-p '{} '{})", t2, t1));
+
+        eval_assert(
+            ctx,
+            "(time-less-p '(1758549821506644000 . 1000000000) '(1758549821506645 . 1000000))",
+        );
+
+        eval_assert_not(
+            ctx,
+            "(time-less-p '(1758549821506645 . 1000000) '(1758549821506644000 . 1000000000))",
+        );
+
+        eval_assert_not(
+            ctx,
+            "(time-less-p '(1758549821506646000 . 1000000000) '(1758549821506645 . 1000000))",
+        );
+
+        eval_assert(
+            ctx,
+            "(time-less-p '(1758549821506645 . 1000000) '(1758549821506646000 . 1000000000))",
+        );
+
+        eval_assert_not(
+            ctx,
+            "(time-less-p '(1758549821506646000 . 1000000000) 1758549821)",
+        );
+
+        eval_assert(
+            ctx,
+            "(time-less-p 1758549821 '(1758549821506646000 . 1000000000))",
+        );
+
+        eval_assert(
+            ctx,
+            "(time-less-p '(1758549821506646000 . 1000000000) 1758549822)",
+        );
+
+        eval_assert_not(
+            ctx,
+            "(time-less-p 1758549822 '(1758549821506646000 . 1000000000))",
+        );
+
+        assert_eq!(
+            ctx.eval_string("(time-less-p '(test . 10) 1758549822)")
+                .unwrap_err()
+                .format(ctx),
+            r#"ERR TypeMismatch: expected (ticks . hz) pair
+<eval_string>:1.15-1.26:  at (test . 10)
+<eval_string>:1.1-1.38:  at (time-less-p '(test . 10) 1758549822)
+"#
+        );
+
+        assert_eq!(
+            ctx.eval_string("(time-less-p 'test 1758549822)")
+                .unwrap_err()
+                .format(ctx),
+            r#"ERR TypeMismatch: expected integer or (ticks . hz) pair
+<eval_string>:1.15-1.19:  at test
+<eval_string>:1.1-1.31:  at (time-less-p 'test 1758549822)
+"#
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_time_equal_p() -> Result<(), Error> {
+        let mut ctx = TulispContext::new();
+        let ctx = &mut ctx;
+        super::add(ctx);
+
+        let t1 = ctx.eval_string("(current-time)").unwrap();
+        let t2 = ctx.eval_string("(current-time)").unwrap();
+
+        eval_assert(ctx, &format!("(time-equal-p '{} '{})", t1, t1));
+
+        eval_assert_not(ctx, &format!("(time-equal-p '{} '{})", t1, t2));
+
+        eval_assert(
+            ctx,
+            "(time-equal-p '(1758549821506645000 . 1000000000) '(1758549821506645 . 1000000))",
+        );
+
+        eval_assert(
+            ctx,
+            "(time-equal-p '(1758549821506645 . 1000000) '(1758549821506645000 . 1000000000))",
+        );
+
+        eval_assert_not(
+            ctx,
+            "(time-equal-p '(1758549821506645001 . 1000000000) '(1758549821506645 . 1000000))",
+        );
+
+        eval_assert_not(
+            ctx,
+            "(time-equal-p '(1758549821506645 . 1000000) '(1758549821506645001 . 1000000000))",
+        );
+
+        eval_assert_not(
+            ctx,
+            "(time-equal-p '(1758549821506645 . 1000000) 1758549821)",
+        );
+
+        eval_assert(
+            ctx,
+            "(time-equal-p '(1758549821000000 . 1000000) 1758549821)",
+        );
+
+        eval_assert(
+            ctx,
+            "(time-equal-p 1758549821 '(1758549821000000 . 1000000))",
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_time_add_subtract() -> Result<(), Error> {
+        let mut ctx = TulispContext::new();
+        let ctx = &mut ctx;
+        super::add(ctx);
+
+        let t1 = "(1758549821506645000 . 1000000000)";
+
+        eval_assert_equal(
+            ctx,
+            &format!("(time-add '{t1} '(1000 . 1000000000))"),
+            "'(1758549821506646000 . 1000000000)",
+        );
+
+        eval_assert_equal(
+            ctx,
+            &format!("(time-add '{t1} '(1 . 1000000))"),
+            "'(1758549821506646000 . 1000000000)",
+        );
+
+        eval_assert_equal(
+            ctx,
+            &format!("(time-add '{t1} '(1 . 1))"),
+            "'(1758549822506645000 . 1000000000)",
+        );
+
+        eval_assert_equal(
+            ctx,
+            &format!("(time-add 1 '{t1})"),
+            "'(1758549822506645000 . 1000000000)",
+        );
+
+        eval_assert_equal(
+            ctx,
+            &format!("(time-add '{t1} 1)"),
+            "'(1758549822506645000 . 1000000000)",
+        );
+
+        eval_assert_equal(
+            ctx,
+            &format!("(time-subtract '{t1} '(1000 . 1000000000))"),
+            "'(1758549821506644000 . 1000000000)",
+        );
+
+        eval_assert_equal(
+            ctx,
+            &format!("(time-subtract '{t1} '(1 . 1000000))"),
+            "'(1758549821506644000 . 1000000000)",
+        );
+
+        eval_assert_equal(
+            ctx,
+            &format!("(time-subtract '{t1} '(1 . 1))"),
+            "'(1758549820506645000 . 1000000000)",
+        );
+
+        eval_assert_equal(
+            ctx,
+            &format!("(time-subtract '{t1} 1)"),
+            "'(1758549820506645000 . 1000000000)",
+        );
+
+        Ok(())
+    }
+}

--- a/src/builtin/mod.rs
+++ b/src/builtin/mod.rs
@@ -140,6 +140,27 @@ Click [here](https://www.gnu.org/software/emacs/manual/html_node/elisp/Hash-Tabl
 | `puthash`          | ☑️     |         |
 | `gethash`          | ☑️     |         |
 
+## Time Calculations
+
+These functions are described in the [time of
+ day](https://www.gnu.org/software/emacs/manual/html_node/elisp/Time-of-Day.html)
+ and [time
+ calculations](https://www.gnu.org/software/emacs/manual/html_node/elisp/Time-Calculations.html)
+ Emacs lisp manual pages.
+
+`time-less-p`, `time-equal-p`, `test-subtract`, `test-add` all take two arguments.  The
+arguments can be integers representing a number of seconds since the Unix epoch,
+or they can be `(ticks . hz)` values, representing `ticks/hz` values seconds since
+the unix epoch.
+
+| Name            | Status | Details                                                                               |
+|-----------------|--------|---------------------------------------------------------------------------------------|
+| `current-time`  | ☑️      | Returns a `(ticks . hz)` value, usually with a hz value of 1000000000, corresponding to a nano-second resolution.
+| `time-less-p`   | ☑️      |                                                     |
+| `time-equal-p`  | ☑️      |                                                     |
+| `test-subtract` | ☑️      |                                                     |
+| `test-add`      | ☑️      |                                                     |
+
 ## Others
 
 These functions need to be organized into categories.  They are grouped here for now.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,3 +106,24 @@ pub use value::TulispValue;
 
 mod object;
 pub use object::TulispObject;
+
+#[cfg(test)]
+mod test_utils {
+    #[track_caller]
+    pub(crate) fn eval_assert_equal(ctx: &mut crate::TulispContext, a: &str, b: &str) {
+        assert!(crate::TulispObject::equal(
+            &ctx.eval_string(a).unwrap(),
+            &ctx.eval_string(b).unwrap(),
+        ))
+    }
+
+    #[track_caller]
+    pub(crate) fn eval_assert(ctx: &mut crate::TulispContext, a: &str) {
+        assert!(ctx.eval_string(a).unwrap().is_truthy())
+    }
+
+    #[track_caller]
+    pub(crate) fn eval_assert_not(ctx: &mut crate::TulispContext, a: &str) {
+        assert!(ctx.eval_string(a).unwrap().null())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,19 +111,27 @@ pub use object::TulispObject;
 mod test_utils {
     #[track_caller]
     pub(crate) fn eval_assert_equal(ctx: &mut crate::TulispContext, a: &str, b: &str) {
-        assert!(crate::TulispObject::equal(
-            &ctx.eval_string(a).unwrap(),
-            &ctx.eval_string(b).unwrap(),
-        ))
+        let av = ctx.eval_string(a).unwrap();
+        let bv = ctx.eval_string(b).unwrap();
+        assert!(
+            crate::TulispObject::equal(&av, &bv),
+            "{}({}) != {}({})",
+            a,
+            av,
+            b,
+            bv
+        );
     }
 
     #[track_caller]
     pub(crate) fn eval_assert(ctx: &mut crate::TulispContext, a: &str) {
-        assert!(ctx.eval_string(a).unwrap().is_truthy())
+        let av = ctx.eval_string(a).unwrap();
+        assert!(av.is_truthy(), "{}({}) is not true", a, av);
     }
 
     #[track_caller]
     pub(crate) fn eval_assert_not(ctx: &mut crate::TulispContext, a: &str) {
-        assert!(ctx.eval_string(a).unwrap().null())
+        let av = ctx.eval_string(a).unwrap();
+        assert!(av.null(), "{}({}) is not nil", a, av);
     }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -86,7 +86,7 @@ impl TryFrom<TulispObject> for DefunParams {
 }
 
 impl DefunParams {
-    pub(crate) fn iter(&self) -> std::slice::Iter<DefunParam> {
+    pub(crate) fn iter(&self) -> std::slice::Iter<'_, DefunParam> {
         self.params.iter()
     }
 


### PR DESCRIPTION
There is no wall clock support, because the rust standard library doesn't provide it.