### PR TITLE
Add validation for too few arguments in destruct_bind macros

### DIFF
--- a/src/context/add_function.rs
+++ b/src/context/add_function.rs
@@ -568,6 +568,13 @@ mod tests {
             (a + b).round() as i64
         });
         eval_assert_equal(ctx, "(let ((a 3.5) (b 4.2))(add_round a b))", "8");
+        eval_assert_error(
+            ctx,
+            "(add_round 2)",
+            r#"ERR TypeMismatch: Too few arguments
+<eval_string>:1.1-1.14:  at (add_round 2)
+"#,
+        );
 
         ctx.add_function("greet", |name: String| format!("Hello, {}!", name));
         eval_assert_equal(ctx, r#"(greet "Alice")"#, r#""Hello, Alice!""#);
@@ -621,6 +628,13 @@ mod tests {
             "(power 2 3 4)",
             r#"ERR TypeMismatch: Too many arguments
 <eval_string>:1.1-1.14:  at (power 2 3 4)
+"#,
+        );
+        eval_assert_error(
+            ctx,
+            "(power)",
+            r#"ERR TypeMismatch: Too few arguments
+<eval_string>:1.1-1.8:  at (power)
 "#,
         );
         Ok(())

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -115,6 +115,11 @@ fn main() -> Result<(), Error> {
 #[macro_export]
 macro_rules! destruct_bind {
     (@reqr $vv:ident, $var:ident) => {
+        if !$vv.consp() {
+            return Err($crate::Error::new(
+                $crate::ErrorKind::TypeMismatch,"Too few arguments".to_string()
+            ));
+        }
         let $var = $vv.car()?;
         let $vv = $vv.cdr()?;
     };
@@ -170,6 +175,11 @@ macro_rules! destruct_bind {
 #[macro_export]
 macro_rules! destruct_eval_bind {
     (@reqr $ctx:ident, $vv:ident, $var:ident) => {
+        if !$vv.consp() {
+            return Err($crate::Error::new(
+                $crate::ErrorKind::TypeMismatch,"Too few arguments".to_string()
+            ));
+        }
         let $var = $vv.car_and_then(|x| $ctx.eval(x))?;
         let $vv = $vv.cdr()?;
     };

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -979,9 +979,9 @@ fn test_sort() -> Result<(), Error> {
     }
     tulisp_assert! {
         program: "(sort '(20 10 30 15 45))",
-        error: r#"ERR Undefined: function is void: nil
+        error: r#"ERR TypeMismatch: Too few arguments
 <eval_string>:1.1-1.25:  at (sort '(20 10 30 15 45))
-"#
+"#,
     }
     tulisp_assert! {
         program: "(defun << (v1 v2) (> v1 v2)) (sort '(20 10 30 15 45) '<<)",


### PR DESCRIPTION
Closes #86 