### PR TITLE
Lexical binding semantics for the tree-walker

### DIFF
--- a/src/builtin/functions/core.rs
+++ b/src/builtin/functions/core.rs
@@ -319,6 +319,20 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         Ok(value)
     });
 
+    /// RAII guard that pops dynamic (`defvar`-declared) let bindings
+    /// from their symbol stacks on scope exit, including the error path
+    /// when the body returns `?` partway through.
+    struct DynamicScopeGuard {
+        names: Vec<TulispObject>,
+    }
+    impl Drop for DynamicScopeGuard {
+        fn drop(&mut self) {
+            for name in self.names.drain(..).rev() {
+                let _ = name.unset();
+            }
+        }
+    }
+
     fn impl_let(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
         destruct_bind!((varlist &rest body) = args);
         if !body.consp() {
@@ -326,11 +340,17 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                 "let: expected varlist and body".to_string(),
             ));
         }
-        // Create fresh LexicalBindings per evaluation and rewrite the
-        // body so references resolve to those bindings. Initializers are
-        // evaluated in the scope of previously-bound let vars (same as
-        // `let*` — tulisp has always had `let` behave this way).
+        // For non-special vars, create a fresh LexicalBinding per
+        // evaluation and rewrite the body to reference it.
+        // For `defvar`-declared (special/dynamic) vars, push onto the
+        // symbol's own stack instead — matching Emacs' behavior under
+        // `lexical-binding: t` for declared variables. The dynamic guard
+        // unwinds those pushes on scope exit.
+        // Initializers are evaluated in the scope of previously-bound
+        // let vars (same as `let*` — tulisp has always had `let` behave
+        // this way).
         let mut mappings: Vec<(TulispObject, TulispObject)> = Vec::new();
+        let mut dynamic_guard = DynamicScopeGuard { names: Vec::new() };
         for varitem in varlist.base_iter() {
             let (name, initial) = if varitem.symbolp() {
                 (varitem, TulispObject::nil())
@@ -358,9 +378,14 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     varitem
                 )));
             };
-            let lex = TulispObject::lexical_binding(name.clone());
-            lex.set(initial)?;
-            mappings.push((name, lex));
+            if name.is_special() {
+                name.set_scope(initial)?;
+                dynamic_guard.names.push(name);
+            } else {
+                let lex = TulispObject::lexical_binding(name.clone());
+                lex.set(initial)?;
+                mappings.push((name, lex));
+            }
         }
 
         let rewritten = substitute_lexical(body, &mappings)?;
@@ -407,39 +432,6 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         };
         let params: DefunParams = params.try_into()?;
         let param_names: Vec<_> = params.iter().map(|x| x.param.clone()).collect();
-
-        fn capture_inside_quoted(
-            captured_vars: &mut Vec<(TulispObject, TulispObject)>,
-            exclude: &[TulispObject],
-            value: TulispObject,
-        ) -> Result<TulispObject, Error> {
-            let inner_ref = value.inner_ref();
-            let res = match &inner_ref.0 {
-                TulispValue::Backquote { value } => TulispValue::Backquote {
-                    value: capture_variables(captured_vars, exclude, value.clone())?,
-                }
-                .into_ref(value.span()),
-                TulispValue::Unquote { value } => TulispValue::Unquote {
-                    value: capture_variables(captured_vars, exclude, value.clone())?,
-                }
-                .into_ref(value.span()),
-                TulispValue::Splice { value } => TulispValue::Splice {
-                    value: capture_variables(captured_vars, exclude, value.clone())?,
-                }
-                .into_ref(value.span()),
-                TulispValue::Sharpquote { value } => TulispValue::Sharpquote {
-                    value: capture_variables(captured_vars, exclude, value.clone())?,
-                }
-                .into_ref(value.span()),
-                // `Quote` is NOT descended into: `'x` is a literal
-                // symbol (e.g. an alist key), not a variable reference.
-                _ => {
-                    drop(inner_ref);
-                    value
-                }
-            };
-            Ok(res)
-        }
 
         fn slice_contains(vec: &[TulispObject], item: &TulispObject) -> bool {
             for i in vec {
@@ -497,34 +489,104 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         fn capture_variables(
             captured_vars: &mut Vec<(TulispObject, TulispObject)>,
             exclude: &[TulispObject],
-            mut body: TulispObject,
+            body: TulispObject,
         ) -> Result<TulispObject, Error> {
-            let result = TulispObject::nil().with_span(body.span());
+            capture_variables_inner(captured_vars, exclude, body, 0)
+        }
+
+        // `quote_depth` tracks quasi-quote nesting: 0 = code context
+        // (substitute/capture vars); >0 = inside a backquote (data
+        // context — literal symbols are not var references). Unquote /
+        // splice decrement it (back to code), backquote increments.
+        fn capture_variables_inner(
+            captured_vars: &mut Vec<(TulispObject, TulispObject)>,
+            exclude: &[TulispObject],
+            mut body: TulispObject,
+            quote_depth: u32,
+        ) -> Result<TulispObject, Error> {
             if !body.consp() {
-                if body.symbolp() {
-                    return capture_symbol(captured_vars, exclude, body);
-                }
-                return capture_inside_quoted(captured_vars, exclude, body);
+                let inner_ref = body.inner_ref();
+                return match &inner_ref.0 {
+                    TulispValue::Symbol { .. } | TulispValue::LexicalBinding { .. } => {
+                        drop(inner_ref);
+                        if quote_depth > 0 {
+                            Ok(body)
+                        } else {
+                            capture_symbol(captured_vars, exclude, body)
+                        }
+                    }
+                    TulispValue::Backquote { value } => Ok(TulispValue::Backquote {
+                        value: capture_variables_inner(
+                            captured_vars,
+                            exclude,
+                            value.clone(),
+                            quote_depth + 1,
+                        )?,
+                    }
+                    .into_ref(body.span())),
+                    TulispValue::Unquote { value } => Ok(TulispValue::Unquote {
+                        value: capture_variables_inner(
+                            captured_vars,
+                            exclude,
+                            value.clone(),
+                            quote_depth.saturating_sub(1),
+                        )?,
+                    }
+                    .into_ref(body.span())),
+                    TulispValue::Splice { value } => Ok(TulispValue::Splice {
+                        value: capture_variables_inner(
+                            captured_vars,
+                            exclude,
+                            value.clone(),
+                            quote_depth.saturating_sub(1),
+                        )?,
+                    }
+                    .into_ref(body.span())),
+                    TulispValue::Sharpquote { value } if quote_depth == 0 => {
+                        Ok(TulispValue::Sharpquote {
+                            value: capture_variables_inner(
+                                captured_vars,
+                                exclude,
+                                value.clone(),
+                                quote_depth,
+                            )?,
+                        }
+                        .into_ref(body.span()))
+                    }
+                    // `Quote` is always data — don't descend.
+                    _ => {
+                        drop(inner_ref);
+                        Ok(body)
+                    }
+                };
             }
 
+            // At code level, `(quote X)` written as a list form is
+            // data-only — don't descend into X.
+            if quote_depth == 0
+                && let Ok(car) = body.car()
+                && let Ok(name) = car.as_symbol()
+                && name == "quote"
+            {
+                return Ok(body);
+            }
+
+            let result = TulispObject::nil().with_span(body.span());
             loop {
                 let car = body.car()?;
-                if car.consp() {
-                    result.push(capture_variables(captured_vars, exclude, car)?)?;
-                } else if car.symbolp() {
-                    result.push(capture_symbol(captured_vars, exclude, car)?)?;
-                } else {
-                    result.push(capture_inside_quoted(captured_vars, exclude, car)?)?;
-                }
+                result
+                    .push(capture_variables_inner(captured_vars, exclude, car, quote_depth)?)?;
                 let cdr = body.cdr()?;
                 if cdr.null() {
                     break;
                 }
-                if cdr.symbolp() {
-                    result.append(capture_symbol(captured_vars, exclude, cdr)?)?;
-                    break;
-                } else if !cdr.consp() {
-                    result.append(capture_inside_quoted(captured_vars, exclude, cdr)?)?;
+                if !cdr.consp() {
+                    result.append(capture_variables_inner(
+                        captured_vars,
+                        exclude,
+                        cdr,
+                        quote_depth,
+                    )?)?;
                     break;
                 }
                 body = cdr;
@@ -744,6 +806,11 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                 "defvar: first argument must be a symbol".to_string(),
             ));
         }
+        // Flip the symbol's `special` flag so subsequent let/let* and
+        // reference-rewrite paths treat it as dynamic (Emacs' behavior
+        // under `lexical-binding: t`). Done before any initval eval so
+        // the flag is set even if initval errors.
+        name.set_special()?;
         if !name.boundp() {
             let val = ctx.eval(&initval)?;
             name.set(val)?;

--- a/src/builtin/functions/core.rs
+++ b/src/builtin/functions/core.rs
@@ -2,13 +2,13 @@ use crate::Number;
 use crate::TulispObject;
 use crate::TulispValue;
 use crate::cons::Cons;
-use crate::context::Scope;
 use crate::context::TulispContext;
 use crate::destruct_eval_bind;
 use crate::error::Error;
 use crate::eval::DummyEval;
 use crate::eval::Eval;
 use crate::eval::EvalInto;
+use crate::eval::substitute_lexical;
 use crate::lists;
 use crate::value::DefunParams;
 use crate::{destruct_bind, list};
@@ -320,39 +320,51 @@ pub(crate) fn add(ctx: &mut TulispContext) {
     });
 
     fn impl_let(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
-        destruct_bind!((varlist &rest rest) = args);
-        if !rest.consp() {
+        destruct_bind!((varlist &rest body) = args);
+        if !body.consp() {
             return Err(Error::type_mismatch(
                 "let: expected varlist and body".to_string(),
             ));
         }
-        let mut local = Scope::default();
+        // Create fresh LexicalBindings per evaluation and rewrite the
+        // body so references resolve to those bindings. Initializers are
+        // evaluated in the scope of previously-bound let vars (same as
+        // `let*` — tulisp has always had `let` behave this way).
+        let mut mappings: Vec<(TulispObject, TulispObject)> = Vec::new();
         for varitem in varlist.base_iter() {
-            if varitem.symbolp() {
-                local.set(varitem, TulispObject::nil())?;
+            let (name, initial) = if varitem.symbolp() {
+                (varitem, TulispObject::nil())
             } else if varitem.consp() {
                 destruct_bind!((&optional name value &rest rest) = varitem);
                 if name.null() {
                     return Err(Error::syntax_error("let varitem requires name".to_string()));
+                }
+                if !name.symbolp() {
+                    return Err(Error::type_mismatch(format!(
+                        "Expected Symbol: Can't assign to {name}"
+                    )));
                 }
                 if !rest.null() {
                     return Err(Error::syntax_error(
                         "let varitem has too many values".to_string(),
                     ));
                 }
-                local.set(name, ctx.eval(&value)?)?;
+                let value_expr = substitute_lexical(value, &mappings)?;
+                let initial = ctx.eval(&value_expr)?;
+                (name, initial)
             } else {
                 return Err(Error::syntax_error(format!(
                     "varitems inside a let-varlist should be a var or a binding: {}",
                     varitem
                 )));
             };
+            let lex = TulispObject::lexical_binding(name.clone());
+            lex.set(initial)?;
+            mappings.push((name, lex));
         }
 
-        let ret = ctx.eval_progn(&rest);
-        local.remove_all()?;
-
-        ret
+        let rewritten = substitute_lexical(body, &mappings)?;
+        ctx.eval_progn(&rewritten)
     }
     ctx.defspecial("let", impl_let);
     ctx.defspecial("let*", impl_let);
@@ -371,12 +383,16 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                 println!("mark_tail_calls error: {:?}", e);
                 e
             })?;
+            // Pre-rewrite the body so each param reference points at a
+            // shared `LexicalBinding` allocated once here. Call-time
+            // evaluation then only push/pops values onto the binding's
+            // thread-local stack, avoiding per-call AST clones (fib was
+            // 10.6× slower without this).
+            let raw_params: DefunParams = params.try_into()?;
+            let (params, mappings) = raw_params.bind_as_lexical();
+            let body = substitute_lexical(body, &mappings)?;
             name.set_global(
-                TulispValue::Lambda {
-                    params: params.try_into()?,
-                    body,
-                }
-                .into_ref(None),
+                TulispValue::Lambda { params, body }.into_ref(None),
             )?;
             Ok(TulispObject::nil())
         }
@@ -415,10 +431,8 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     value: capture_variables(captured_vars, exclude, value.clone())?,
                 }
                 .into_ref(value.span()),
-                TulispValue::Quote { value } => TulispValue::Quote {
-                    value: capture_variables(captured_vars, exclude, value.clone())?,
-                }
-                .into_ref(value.span()),
+                // `Quote` is NOT descended into: `'x` is a literal
+                // symbol (e.g. an alist key), not a variable reference.
                 _ => {
                     drop(inner_ref);
                     value
@@ -450,8 +464,30 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                         return Ok(to.clone().with_span(symbol.span()));
                     }
                 }
-                let new_var = TulispObject::lexical_binding(symbol.clone());
-                new_var.set(symbol.get()?)?;
+                // Share the enclosing scope's slot with the closure
+                // so `setq` on either side is visible to both —
+                // matching Emacs' `lexical-binding: t` semantics.
+                let slot_opt = {
+                    let inner = symbol.inner_ref();
+                    match &inner.0 {
+                        crate::value::TulispValue::LexicalBinding { binding } => {
+                            Some((binding.current_slot(), binding.name().to_string()))
+                        }
+                        _ => None,
+                    }
+                };
+                let slot = match slot_opt {
+                    Some((Some(slot), _)) => slot,
+                    Some((None, name)) => {
+                        return Err(Error::uninitialized(format!(
+                            "Variable definition is void: {}",
+                            name
+                        )));
+                    }
+                    None => return Ok(symbol),
+                };
+                let new_var =
+                    TulispObject::lexical_binding_captured(symbol.clone(), slot);
                 captured_vars.push((symbol, new_var.clone()));
                 return Ok(new_var);
             }
@@ -497,6 +533,12 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         }
 
         let body = capture_variables(&mut vec![], &param_names, body)?;
+        // After capture_variables, free vars in body point at captured
+        // LexicalBindings from the enclosing scope; param references
+        // are still raw symbols. Pre-rewrite them to the new
+        // per-param LexicalBindings so calls are push/pop only.
+        let (params, mappings) = params.bind_as_lexical();
+        let body = substitute_lexical(body, &mappings)?;
         Ok(TulispValue::Lambda { params, body }.into_ref(None))
     }
     ctx.defspecial("lambda", lambda);
@@ -508,12 +550,11 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         } else {
             rest
         };
+        let raw_params: DefunParams = params.try_into()?;
+        let (params, mappings) = raw_params.bind_as_lexical();
+        let body = substitute_lexical(body, &mappings)?;
         name.set_scope(
-            TulispValue::Defmacro {
-                params: params.try_into()?,
-                body,
-            }
-            .into_ref(None),
+            TulispValue::Defmacro { params, body }.into_ref(None),
         )?;
         Ok(TulispObject::nil())
     });
@@ -577,28 +618,37 @@ pub(crate) fn add(ctx: &mut TulispContext) {
     ctx.defspecial("dolist", |ctx, args| {
         destruct_bind!((spec &rest body) = args);
         destruct_bind!((var list &optional result) = spec);
+        // Under Emacs' `lexical-binding: t`, dolist freshly binds the
+        // loop variable at each iteration — equivalent to `(while tail
+        // (let ((var (car tail))) body))`. So closures captured in
+        // different iterations get distinct slots. `result` is
+        // evaluated in the *outer* scope and does not see `var`.
+        let lex = TulispObject::lexical_binding(var.clone());
+        let mappings = vec![(var, lex.clone())];
+        let body = substitute_lexical(body, &mappings)?;
         let mut list = ctx.eval(&list)?;
-        var.set_scope(list.car()?)?;
         while list.is_truthy() {
-            let eval_res = ctx.eval_progn(&body);
-            eval_res?;
+            lex.set_scope(list.car()?)?;
+            let res = ctx.eval_progn(&body);
+            lex.unset()?;
+            res?;
             list = list.cdr()?;
-            var.set_unchecked(list.car()?);
         }
-        var.unset()?;
         ctx.eval(&result)
     });
 
     ctx.defspecial("dotimes", |ctx, args| {
         destruct_bind!((spec &rest body) = args);
         destruct_bind!((var count &optional result) = spec);
-        var.set_scope(TulispObject::from(0))?;
+        let lex = TulispObject::lexical_binding(var.clone());
+        let mappings = vec![(var, lex.clone())];
+        let body = substitute_lexical(body, &mappings)?;
         for counter in 0..count.as_int()? {
-            var.set_unchecked(TulispObject::from(counter));
-            let eval_res = ctx.eval_progn(&body);
-            eval_res?;
+            lex.set_scope(TulispObject::from(counter))?;
+            let res = ctx.eval_progn(&body);
+            lex.unset()?;
+            res?;
         }
-        var.unset()?;
         ctx.eval(&result)
     });
 

--- a/src/builtin/functions/core.rs
+++ b/src/builtin/functions/core.rs
@@ -10,7 +10,8 @@ use crate::eval::Eval;
 use crate::eval::EvalInto;
 use crate::eval::substitute_lexical;
 use crate::lists;
-use crate::value::DefunParams;
+use crate::object::wrappers::generic::{Shared, SharedMut};
+use crate::value::{DefunParams, LexAllocator};
 use crate::{destruct_bind, list};
 use std::convert::TryInto;
 
@@ -387,8 +388,12 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                 name.set_scope(initial)?;
                 dynamic_guard.names.push(name);
             } else {
-                let slot = crate::object::wrappers::generic::SharedMut::new(initial);
-                let lex = TulispObject::lexical_binding_captured(name.clone(), slot);
+                let slot = SharedMut::new(initial);
+                let lex = TulispObject::lexical_binding_captured(
+                    ctx.lex_allocator.clone(),
+                    name.clone(),
+                    slot,
+                );
                 mappings.push((name, lex));
             }
         }
@@ -419,7 +424,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
             // thread-local stack, avoiding per-call AST clones (fib was
             // 10.6× slower without this).
             let raw_params: DefunParams = params.try_into()?;
-            let (params, mappings) = raw_params.bind_as_lexical();
+            let (params, mappings) = raw_params.bind_as_lexical(&ctx.lex_allocator);
             let body = substitute_lexical(body, &mappings)?;
             name.set_global(
                 TulispValue::Lambda { params, body }.into_ref(None),
@@ -428,7 +433,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         }
     });
 
-    fn lambda(_ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
+    fn lambda(ctx: &mut TulispContext, args: &TulispObject) -> Result<TulispObject, Error> {
         destruct_bind!((params &rest rest) = args);
         let body = if rest.car()?.as_string().is_ok() {
             rest.cdr()?
@@ -448,6 +453,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         }
 
         fn capture_symbol(
+            allocator: &Shared<LexAllocator>,
             captured_vars: &mut Vec<(TulispObject, TulispObject)>,
             exclude: &[TulispObject],
             symbol: TulispObject,
@@ -484,7 +490,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     None => return Ok(symbol),
                 };
                 let new_var =
-                    TulispObject::lexical_binding_captured(symbol.clone(), slot);
+                    TulispObject::lexical_binding_captured(allocator.clone(), symbol.clone(), slot);
                 captured_vars.push((symbol, new_var.clone()));
                 return Ok(new_var);
             }
@@ -492,11 +498,12 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         }
 
         fn capture_variables(
+            allocator: &Shared<LexAllocator>,
             captured_vars: &mut Vec<(TulispObject, TulispObject)>,
             exclude: &[TulispObject],
             body: TulispObject,
         ) -> Result<TulispObject, Error> {
-            capture_variables_inner(captured_vars, exclude, body, 0)
+            capture_variables_inner(allocator, captured_vars, exclude, body, 0)
         }
 
         // `quote_depth` tracks quasi-quote nesting: 0 = code context
@@ -504,6 +511,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         // context — literal symbols are not var references). Unquote /
         // splice decrement it (back to code), backquote increments.
         fn capture_variables_inner(
+            allocator: &Shared<LexAllocator>,
             captured_vars: &mut Vec<(TulispObject, TulispObject)>,
             exclude: &[TulispObject],
             mut body: TulispObject,
@@ -517,11 +525,12 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                         if quote_depth > 0 {
                             Ok(body)
                         } else {
-                            capture_symbol(captured_vars, exclude, body)
+                            capture_symbol(allocator, captured_vars, exclude, body)
                         }
                     }
                     TulispValue::Backquote { value } => Ok(TulispValue::Backquote {
                         value: capture_variables_inner(
+                            allocator,
                             captured_vars,
                             exclude,
                             value.clone(),
@@ -531,6 +540,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     .into_ref(body.span())),
                     TulispValue::Unquote { value } => Ok(TulispValue::Unquote {
                         value: capture_variables_inner(
+                            allocator,
                             captured_vars,
                             exclude,
                             value.clone(),
@@ -540,6 +550,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     .into_ref(body.span())),
                     TulispValue::Splice { value } => Ok(TulispValue::Splice {
                         value: capture_variables_inner(
+                            allocator,
                             captured_vars,
                             exclude,
                             value.clone(),
@@ -550,6 +561,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                     TulispValue::Sharpquote { value } if quote_depth == 0 => {
                         Ok(TulispValue::Sharpquote {
                             value: capture_variables_inner(
+                                allocator,
                                 captured_vars,
                                 exclude,
                                 value.clone(),
@@ -580,13 +592,14 @@ pub(crate) fn add(ctx: &mut TulispContext) {
             loop {
                 let car = body.car()?;
                 result
-                    .push(capture_variables_inner(captured_vars, exclude, car, quote_depth)?)?;
+                    .push(capture_variables_inner(allocator, captured_vars, exclude, car, quote_depth)?)?;
                 let cdr = body.cdr()?;
                 if cdr.null() {
                     break;
                 }
                 if !cdr.consp() {
                     result.append(capture_variables_inner(
+                        allocator,
                         captured_vars,
                         exclude,
                         cdr,
@@ -599,18 +612,18 @@ pub(crate) fn add(ctx: &mut TulispContext) {
             Ok(result)
         }
 
-        let body = capture_variables(&mut vec![], &param_names, body)?;
+        let body = capture_variables(&ctx.lex_allocator, &mut vec![], &param_names, body)?;
         // After capture_variables, free vars in body point at captured
         // LexicalBindings from the enclosing scope; param references
         // are still raw symbols. Pre-rewrite them to the new
         // per-param LexicalBindings so calls are push/pop only.
-        let (params, mappings) = params.bind_as_lexical();
+        let (params, mappings) = params.bind_as_lexical(&ctx.lex_allocator);
         let body = substitute_lexical(body, &mappings)?;
         Ok(TulispValue::Lambda { params, body }.into_ref(None))
     }
     ctx.defspecial("lambda", lambda);
 
-    ctx.defspecial("defmacro", |_ctx, args| {
+    ctx.defspecial("defmacro", |ctx, args| {
         destruct_bind!((name params &rest rest) = args);
         let body = if rest.car()?.as_string().is_ok() {
             rest.cdr()?
@@ -618,7 +631,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
             rest
         };
         let raw_params: DefunParams = params.try_into()?;
-        let (params, mappings) = raw_params.bind_as_lexical();
+        let (params, mappings) = raw_params.bind_as_lexical(&ctx.lex_allocator);
         let body = substitute_lexical(body, &mappings)?;
         name.set_scope(
             TulispValue::Defmacro { params, body }.into_ref(None),
@@ -690,7 +703,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         // (let ((var (car tail))) body))`. So closures captured in
         // different iterations get distinct slots. `result` is
         // evaluated in the *outer* scope and does not see `var`.
-        let lex = TulispObject::lexical_binding(var.clone());
+        let lex = TulispObject::lexical_binding(ctx.lex_allocator.clone(), var.clone());
         let mappings = vec![(var, lex.clone())];
         let body = substitute_lexical(body, &mappings)?;
         let mut list = ctx.eval(&list)?;
@@ -707,7 +720,7 @@ pub(crate) fn add(ctx: &mut TulispContext) {
     ctx.defspecial("dotimes", |ctx, args| {
         destruct_bind!((spec &rest body) = args);
         destruct_bind!((var count &optional result) = spec);
-        let lex = TulispObject::lexical_binding(var.clone());
+        let lex = TulispObject::lexical_binding(ctx.lex_allocator.clone(), var.clone());
         let mappings = vec![(var, lex.clone())];
         let body = substitute_lexical(body, &mappings)?;
         for counter in 0..count.as_int()? {

--- a/src/builtin/functions/core.rs
+++ b/src/builtin/functions/core.rs
@@ -319,9 +319,11 @@ pub(crate) fn add(ctx: &mut TulispContext) {
         Ok(value)
     });
 
-    /// RAII guard that pops dynamic (`defvar`-declared) let bindings
-    /// from their symbol stacks on scope exit, including the error path
-    /// when the body returns `?` partway through.
+    /// RAII guard that unwinds dynamic (`defvar`-declared) let bindings
+    /// on scope exit — including the error path when the body returns
+    /// `?` partway through. Lexical (non-special) let vars don't need a
+    /// guard: they own their slot directly via
+    /// `lexical_binding_captured`, so the slot drops with the binding.
     struct DynamicScopeGuard {
         names: Vec<TulispObject>,
     }
@@ -341,7 +343,10 @@ pub(crate) fn add(ctx: &mut TulispContext) {
             ));
         }
         // For non-special vars, create a fresh LexicalBinding per
-        // evaluation and rewrite the body to reference it.
+        // evaluation that directly owns its slot (via
+        // `lexical_binding_captured`) and rewrite the body to reference
+        // it. The slot drops when the binding drops — no thread-local
+        // stack involvement, no per-call id→stack growth.
         // For `defvar`-declared (special/dynamic) vars, push onto the
         // symbol's own stack instead — matching Emacs' behavior under
         // `lexical-binding: t` for declared variables. The dynamic guard
@@ -382,8 +387,8 @@ pub(crate) fn add(ctx: &mut TulispContext) {
                 name.set_scope(initial)?;
                 dynamic_guard.names.push(name);
             } else {
-                let lex = TulispObject::lexical_binding(name.clone());
-                lex.set(initial)?;
+                let slot = crate::object::wrappers::generic::SharedMut::new(initial);
+                let lex = TulispObject::lexical_binding_captured(name.clone(), slot);
                 mappings.push((name, lex));
             }
         }

--- a/src/context.rs
+++ b/src/context.rs
@@ -22,26 +22,6 @@ use crate::{
     parse::parse,
 };
 
-#[derive(Debug, Default, Clone)]
-pub(crate) struct Scope {
-    pub scope: Vec<TulispObject>,
-}
-
-impl Scope {
-    pub fn set(&mut self, symbol: TulispObject, value: TulispObject) -> Result<(), Error> {
-        symbol.set_scope(value)?;
-        self.scope.push(symbol);
-        Ok(())
-    }
-
-    pub fn remove_all(&self) -> Result<(), Error> {
-        for item in &self.scope {
-            item.unset()?;
-        }
-        Ok(())
-    }
-}
-
 /// Represents an instance of the _Tulisp_ interpreter.
 ///
 /// Owns the
@@ -479,6 +459,12 @@ impl TulispContext {
     }
 
     pub(crate) fn get_filename(&self, file_id: usize) -> String {
-        self.filenames[file_id].clone()
+        // Spans can cross context boundaries (e.g. a lambda parsed in the
+        // parent, funcalled from a child async context that has its own
+        // `filenames`). An unknown file id is not a bug; fall back gracefully.
+        self.filenames
+            .get(file_id)
+            .cloned()
+            .unwrap_or_else(|| "<unknown>".to_string())
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -20,6 +20,7 @@ use crate::{
     list,
     object::wrappers::{TulispFn, generic::Shared},
     parse::parse,
+    value::LexAllocator,
 };
 
 /// Represents an instance of the _Tulisp_ interpreter.
@@ -34,6 +35,7 @@ pub struct TulispContext {
     obarray: HashMap<String, TulispObject>,
     pub(crate) filenames: Vec<String>,
     pub(crate) load_path: Option<PathBuf>,
+    pub(crate) lex_allocator: Shared<LexAllocator>,
     #[cfg(feature = "etags")]
     pub(crate) tags_table: HashMap<String, HashMap<String, usize>>,
 }
@@ -51,6 +53,7 @@ impl TulispContext {
             obarray: HashMap::new(),
             filenames: vec!["<eval_string>".to_string()],
             load_path: None,
+            lex_allocator: Shared::new_sized(LexAllocator::new()),
             #[cfg(feature = "etags")]
             tags_table: HashMap::new(),
         };

--- a/src/error.rs
+++ b/src/error.rs
@@ -79,11 +79,46 @@ ErrorKind!(
 ///
 /// Use [format](crate::Error::format) to produce a formatted representation of the error
 /// including backtraces and source code spans.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Error {
     kind: ErrorKind,
     desc: String,
     backtrace: Vec<TulispObject>,
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ERR {}:", self.kind)?;
+        if !self.desc.is_empty() {
+            write!(f, " {}", self.desc)?;
+        }
+        for span_obj in &self.backtrace {
+            if span_obj.numberp() || span_obj.symbolp() || span_obj.stringp() {
+                continue;
+            }
+            let prefix = if let Some(span) = span_obj.span() {
+                format!(
+                    "<file {}>:{}.{}-{}.{}:",
+                    span.file_id, span.start.0, span.start.1, span.end.0, span.end.1
+                )
+            } else {
+                continue;
+            };
+            let string = span_obj.to_string().replace('\n', "\\n");
+            if string.len() > 80 {
+                write!(f, "\n{}  at {:.80}...", prefix, string)?;
+            } else {
+                write!(f, "\n{}  at {}", prefix, string)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(self, f)
+    }
 }
 
 impl Error {

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -4,7 +4,8 @@ pub(crate) use eval_into::EvalInto;
 use std::borrow::Cow;
 
 use crate::{
-    TulispObject, TulispValue, context::TulispContext, error::Error, list, value::DefunParams,
+    TulispObject, TulispValue, context::TulispContext, error::Error, list,
+    value::{DefunParams, LexBinding},
 };
 
 pub(crate) trait Evaluator {
@@ -34,11 +35,12 @@ impl Evaluator for DummyEval {
     }
 }
 
-fn zip_function_args<E: Evaluator>(
+fn eval_function_args<E: Evaluator>(
     ctx: &mut TulispContext,
     params: &DefunParams,
     args: &TulispObject,
-) -> Result<(), Error> {
+) -> Result<Vec<TulispObject>, Error> {
+    let mut out = Vec::new();
     let mut args_iter = args.base_iter();
     for param in params.iter() {
         let val = if param.is_optional {
@@ -66,12 +68,56 @@ fn zip_function_args<E: Evaluator>(
         } else {
             return Err(Error::missing_argument("Too few arguments".to_string()));
         };
-        param.param.set_scope(val)?;
+        out.push(val);
     }
     if args_iter.next().is_some() {
         return Err(Error::invalid_argument("Too many arguments".to_string()));
     }
-    Ok(())
+    Ok(out)
+}
+
+/// RAII guard that pops values from each LexBinding's thread-local
+/// stack when the current call's scope exits (including via `?`). This
+/// keeps the stacks balanced when the body errors partway through.
+struct LexScopeGuard<'a> {
+    bindings: &'a [LexBinding],
+    pushed: usize,
+}
+
+impl<'a> LexScopeGuard<'a> {
+    fn new(bindings: &'a [LexBinding]) -> Self {
+        Self {
+            bindings,
+            pushed: 0,
+        }
+    }
+    fn push(&mut self, val: TulispObject) {
+        self.bindings[self.pushed].push(val);
+        self.pushed += 1;
+    }
+}
+
+impl<'a> Drop for LexScopeGuard<'a> {
+    fn drop(&mut self) {
+        for b in &self.bindings[..self.pushed] {
+            let _ = b.pop();
+        }
+    }
+}
+
+fn lex_bindings_of(params: &DefunParams) -> Result<Vec<LexBinding>, Error> {
+    let mut out = Vec::with_capacity(params.iter().len());
+    for param in params.iter() {
+        let inner = param.param.inner_ref();
+        let TulispValue::LexicalBinding { binding } = &inner.0 else {
+            return Err(Error::type_mismatch(format!(
+                "internal: defun/lambda param was not pre-rewritten to a LexicalBinding: {}",
+                param.param
+            )));
+        };
+        out.push(binding.clone());
+    }
+    Ok(out)
 }
 
 #[inline(always)]
@@ -81,10 +127,17 @@ fn eval_function<E: Evaluator>(
     body: &TulispObject,
     args: &TulispObject,
 ) -> Result<TulispObject, Error> {
-    zip_function_args::<E>(ctx, params, args)?;
-    let result = ctx.eval_progn(body)?;
-    params.unbind()?;
-    Ok(result)
+    let vals = eval_function_args::<E>(ctx, params, args)?;
+    // Params are pre-rewritten at defun/lambda/defmacro creation to
+    // carry a shared `LexicalBinding`; here we just push the arg values
+    // onto each binding's thread-local stack, run the body, and pop.
+    // Concurrent callers use independent stacks.
+    let bindings = lex_bindings_of(params)?;
+    let mut guard = LexScopeGuard::new(&bindings);
+    for val in vals {
+        guard.push(val);
+    }
+    ctx.eval_progn(body)
 }
 
 #[inline(always)]
@@ -235,8 +288,8 @@ pub(crate) fn eval_basic<'a>(
                 value.get().map_err(|e| e.with_trace(expr.clone()))?,
             ))
         }
-        TulispValue::LexicalBinding { value, .. } => Ok(Cow::Owned(
-            value.get().map_err(|e| e.with_trace(expr.clone()))?,
+        TulispValue::LexicalBinding { binding } => Ok(Cow::Owned(
+            binding.get().map_err(|e| e.with_trace(expr.clone()))?,
         )),
         TulispValue::Number { .. }
         | TulispValue::String { .. }
@@ -306,4 +359,81 @@ pub fn macroexpand(ctx: &mut TulispContext, inp: TulispObject) -> Result<TulispO
     } else {
         Ok(x)
     }
+}
+
+/// Walk `body` and replace each occurrence of a symbol listed in
+/// `mappings` with its mapped replacement (typically a freshly-created
+/// `LexicalBinding`). Descends into list, quote, and backquote forms,
+/// matching `capture_variables`'s traversal. Unlike `capture_variables`,
+/// this performs explicit substitution only — it does not auto-capture
+/// free lexically-bound vars.
+pub(crate) fn substitute_lexical(
+    body: TulispObject,
+    mappings: &[(TulispObject, TulispObject)],
+) -> Result<TulispObject, Error> {
+    if mappings.is_empty() {
+        return Ok(body);
+    }
+    let inner_ref = body.inner_ref();
+    let span = body.span();
+    let res = match &inner_ref.0 {
+        TulispValue::Symbol { .. } | TulispValue::LexicalBinding { .. } => {
+            drop(inner_ref);
+            for (from, to) in mappings {
+                if body.eq(from) {
+                    return Ok(to.clone().with_span(span));
+                }
+            }
+            body
+        }
+        TulispValue::List { .. } => {
+            drop(inner_ref);
+            // Preserve the outer list's ctxobj — it caches the function
+            // resolved at parse time for `(fn arg ...)` forms. Dropping
+            // it here would force a symbol lookup on every call.
+            let ctxobj = body.ctxobj();
+            let result = TulispObject::nil().with_span(span).with_ctxobj(ctxobj);
+            let mut cur = body;
+            loop {
+                let car = cur.car()?;
+                result.push(substitute_lexical(car, mappings)?)?;
+                let cdr = cur.cdr()?;
+                if cdr.null() {
+                    break;
+                }
+                if !cdr.consp() {
+                    result.append(substitute_lexical(cdr, mappings)?)?;
+                    break;
+                }
+                cur = cdr;
+            }
+            result
+        }
+        TulispValue::Backquote { value } => TulispValue::Backquote {
+            value: substitute_lexical(value.clone(), mappings)?,
+        }
+        .into_ref(span),
+        TulispValue::Unquote { value } => TulispValue::Unquote {
+            value: substitute_lexical(value.clone(), mappings)?,
+        }
+        .into_ref(span),
+        TulispValue::Splice { value } => TulispValue::Splice {
+            value: substitute_lexical(value.clone(), mappings)?,
+        }
+        .into_ref(span),
+        TulispValue::Sharpquote { value } => TulispValue::Sharpquote {
+            value: substitute_lexical(value.clone(), mappings)?,
+        }
+        .into_ref(span),
+        // `Quote` intentionally does NOT descend — `'x` is a literal
+        // symbol reference (e.g. an alist key), not a variable use.
+        // Rewriting it to a `LexicalBinding` would corrupt data
+        // literals. Backquote is different: it contains `,expr`
+        // unquotes that must be rewritten.
+        _ => {
+            drop(inner_ref);
+            body
+        }
+    };
+    Ok(res)
 }

--- a/src/eval.rs
+++ b/src/eval.rs
@@ -131,7 +131,9 @@ fn eval_function<E: Evaluator>(
     // Params are pre-rewritten at defun/lambda/defmacro creation to
     // carry a shared `LexicalBinding`; here we just push the arg values
     // onto each binding's thread-local stack, run the body, and pop.
-    // Concurrent callers use independent stacks.
+    // Concurrent callers use independent stacks. Function parameters
+    // are always lexical — even for `defvar`-declared names — matching
+    // Emacs' byte-compiler under `lexical-binding: t`.
     let bindings = lex_bindings_of(params)?;
     let mut guard = LexScopeGuard::new(&bindings);
     for val in vals {
@@ -284,9 +286,8 @@ pub(crate) fn eval_basic<'a>(
             if value.is_constant() {
                 return Ok(Cow::Borrowed(expr));
             }
-            Ok(Cow::Owned(
-                value.get().map_err(|e| e.with_trace(expr.clone()))?,
-            ))
+            let got = value.get().map_err(|e| e.with_trace(expr.clone()))?;
+            Ok(Cow::Owned(got))
         }
         TulispValue::LexicalBinding { binding } => Ok(Cow::Owned(
             binding.get().map_err(|e| e.with_trace(expr.clone()))?,
@@ -363,13 +364,20 @@ pub fn macroexpand(ctx: &mut TulispContext, inp: TulispObject) -> Result<TulispO
 
 /// Walk `body` and replace each occurrence of a symbol listed in
 /// `mappings` with its mapped replacement (typically a freshly-created
-/// `LexicalBinding`). Descends into list, quote, and backquote forms,
-/// matching `capture_variables`'s traversal. Unlike `capture_variables`,
-/// this performs explicit substitution only — it does not auto-capture
-/// free lexically-bound vars.
+/// `LexicalBinding`). Only substitutes at code positions — literals
+/// inside `'x`, `(quote x)`, or backquote-but-not-unquote positions
+/// are preserved so data literals (e.g. alist keys) are not corrupted.
 pub(crate) fn substitute_lexical(
     body: TulispObject,
     mappings: &[(TulispObject, TulispObject)],
+) -> Result<TulispObject, Error> {
+    substitute_lexical_inner(body, mappings, 0)
+}
+
+fn substitute_lexical_inner(
+    body: TulispObject,
+    mappings: &[(TulispObject, TulispObject)],
+    quote_depth: u32,
 ) -> Result<TulispObject, Error> {
     if mappings.is_empty() {
         return Ok(body);
@@ -379,15 +387,28 @@ pub(crate) fn substitute_lexical(
     let res = match &inner_ref.0 {
         TulispValue::Symbol { .. } | TulispValue::LexicalBinding { .. } => {
             drop(inner_ref);
-            for (from, to) in mappings {
-                if body.eq(from) {
-                    return Ok(to.clone().with_span(span));
+            if quote_depth > 0 {
+                body
+            } else {
+                for (from, to) in mappings {
+                    if body.eq(from) {
+                        return Ok(to.clone().with_span(span));
+                    }
                 }
+                body
             }
-            body
         }
         TulispValue::List { .. } => {
             drop(inner_ref);
+            // At code level, `(quote X)` written as a list form is
+            // data-only — don't substitute inside X (alist key etc.).
+            if quote_depth == 0
+                && let Ok(car) = body.car()
+                && let Ok(name) = car.as_symbol()
+                && name == "quote"
+            {
+                return Ok(body);
+            }
             // Preserve the outer list's ctxobj — it caches the function
             // resolved at parse time for `(fn arg ...)` forms. Dropping
             // it here would force a symbol lookup on every call.
@@ -396,13 +417,13 @@ pub(crate) fn substitute_lexical(
             let mut cur = body;
             loop {
                 let car = cur.car()?;
-                result.push(substitute_lexical(car, mappings)?)?;
+                result.push(substitute_lexical_inner(car, mappings, quote_depth)?)?;
                 let cdr = cur.cdr()?;
                 if cdr.null() {
                     break;
                 }
                 if !cdr.consp() {
-                    result.append(substitute_lexical(cdr, mappings)?)?;
+                    result.append(substitute_lexical_inner(cdr, mappings, quote_depth)?)?;
                     break;
                 }
                 cur = cdr;
@@ -410,26 +431,34 @@ pub(crate) fn substitute_lexical(
             result
         }
         TulispValue::Backquote { value } => TulispValue::Backquote {
-            value: substitute_lexical(value.clone(), mappings)?,
+            value: substitute_lexical_inner(value.clone(), mappings, quote_depth + 1)?,
         }
         .into_ref(span),
         TulispValue::Unquote { value } => TulispValue::Unquote {
-            value: substitute_lexical(value.clone(), mappings)?,
+            value: substitute_lexical_inner(
+                value.clone(),
+                mappings,
+                quote_depth.saturating_sub(1),
+            )?,
         }
         .into_ref(span),
         TulispValue::Splice { value } => TulispValue::Splice {
-            value: substitute_lexical(value.clone(), mappings)?,
+            value: substitute_lexical_inner(
+                value.clone(),
+                mappings,
+                quote_depth.saturating_sub(1),
+            )?,
         }
         .into_ref(span),
-        TulispValue::Sharpquote { value } => TulispValue::Sharpquote {
-            value: substitute_lexical(value.clone(), mappings)?,
+        TulispValue::Sharpquote { value } if quote_depth == 0 => TulispValue::Sharpquote {
+            value: substitute_lexical_inner(value.clone(), mappings, quote_depth)?,
         }
         .into_ref(span),
         // `Quote` intentionally does NOT descend — `'x` is a literal
         // symbol reference (e.g. an alist key), not a variable use.
         // Rewriting it to a `LexicalBinding` would corrupt data
-        // literals. Backquote is different: it contains `,expr`
-        // unquotes that must be rewritten.
+        // literals. Inside a backquote (quote_depth > 0) Sharpquote
+        // also stays literal.
         _ => {
             drop(inner_ref);
             body

--- a/src/eval/eval_into.rs
+++ b/src/eval/eval_into.rs
@@ -43,9 +43,9 @@ impl EvalInto<Number> for TulispObject {
                 }
                 sym.get_as_number().map_err(|e| e.with_trace(self.clone()))
             }
-            TulispValue::LexicalBinding { value: sym, .. } => {
-                sym.get_as_number().map_err(|e| e.with_trace(self.clone()))
-            }
+            TulispValue::LexicalBinding { binding } => binding
+                .get_as_number()
+                .map_err(|e| e.with_trace(self.clone())),
             TulispValue::List { .. } => eval_form::<Eval>(ctx, self)
                 .map_err(|e| e.with_trace(self.clone()))?
                 .as_number(),
@@ -68,6 +68,9 @@ impl EvalInto<bool> for TulispObject {
                     return Ok(true);
                 }
                 sym.get_as_bool().map_err(|e| e.with_trace(self.clone()))
+            }
+            TulispValue::LexicalBinding { binding } => {
+                binding.get_as_bool().map_err(|e| e.with_trace(self.clone()))
             }
             TulispValue::List { .. } => Ok(eval_form::<Eval>(ctx, self)
                 .map_err(|e| e.with_trace(self.clone()))?

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub use value::TulispValue;
 mod object;
 pub use {
     object::TulispObject, object::conversions::TulispConvertible, object::wrappers::generic::Shared,
+    object::wrappers::generic::SharedMut,
 };
 
 #[cfg(test)]

--- a/src/object.rs
+++ b/src/object.rs
@@ -6,7 +6,7 @@ use crate::{
     cons::{self, Cons},
     error::Error,
     object::wrappers::generic::{Shared, SharedMut, SharedRef},
-    value::TulispAny,
+    value::{LexAllocator, TulispAny},
 };
 
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]
@@ -395,17 +395,21 @@ impl TulispObject {
         TulispValue::symbol(name, constant).into_ref(None)
     }
 
-    pub(crate) fn lexical_binding(symbol: TulispObject) -> TulispObject {
+    pub(crate) fn lexical_binding(
+        allocator: Shared<LexAllocator>,
+        symbol: TulispObject,
+    ) -> TulispObject {
         let span = symbol.span();
-        TulispValue::lexical_binding(symbol).into_ref(span)
+        TulispValue::lexical_binding(allocator, symbol).into_ref(span)
     }
 
     pub(crate) fn lexical_binding_captured(
+        allocator: Shared<LexAllocator>,
         symbol: TulispObject,
-        slot: crate::object::wrappers::generic::SharedMut<TulispObject>,
+        slot: SharedMut<TulispObject>,
     ) -> TulispObject {
         let span = symbol.span();
-        TulispValue::lexical_binding_captured(symbol, slot).into_ref(span)
+        TulispValue::lexical_binding_captured(allocator, symbol, slot).into_ref(span)
     }
 
     pub(crate) fn new(vv: TulispValue, span: Option<Span>) -> TulispObject {

--- a/src/object.rs
+++ b/src/object.rs
@@ -228,6 +228,26 @@ impl TulispObject {
             .map_err(|e| e.with_trace(self.clone()))
     }
 
+    /// Marks `self` as a "special" (dynamically-bound) variable. Once
+    /// set, references to this symbol bypass lexical-binding rewrites
+    /// and always resolve through the symbol's dynamic stack, matching
+    /// Emacs' `defvar` behavior under `lexical-binding: t`.
+    ///
+    /// Returns an Error if `self` is not a `Symbol`.
+    pub(crate) fn set_special(&self) -> Result<(), Error> {
+        self.rc
+            .borrow_mut()
+            .0
+            .set_special()
+            .map_err(|e| e.with_trace(self.clone()))
+    }
+
+    /// Returns `true` if `self` was declared with `defvar` (or otherwise
+    /// marked special). Non-symbols return `false`.
+    pub(crate) fn is_special(&self) -> bool {
+        self.rc.borrow().0.is_special()
+    }
+
     /// Unsets the value from the most recent scope.
     ///
     /// Returns an Error if `self` is not a `Symbol`.

--- a/src/object.rs
+++ b/src/object.rs
@@ -380,20 +380,20 @@ impl TulispObject {
         TulispValue::lexical_binding(symbol).into_ref(span)
     }
 
+    pub(crate) fn lexical_binding_captured(
+        symbol: TulispObject,
+        slot: crate::object::wrappers::generic::SharedMut<TulispObject>,
+    ) -> TulispObject {
+        let span = symbol.span();
+        TulispValue::lexical_binding_captured(symbol, slot).into_ref(span)
+    }
+
     pub(crate) fn new(vv: TulispValue, span: Option<Span>) -> TulispObject {
         Self {
             rc: SharedMut::new((vv, span)),
         }
     }
 
-    /// Sets the value without checking if the symbol is constant, or if it is
-    /// bound.
-    ///
-    /// For use in loops and other places where a set_scope has already been
-    /// done, and the symbol is known to be bound.
-    pub(crate) fn set_unchecked(&self, to_set: TulispObject) {
-        self.rc.borrow_mut().0.set_unchecked(to_set)
-    }
 
     pub(crate) fn set_global(&self, to_set: TulispObject) -> Result<(), Error> {
         self.rc.borrow_mut().0.set_global(to_set)

--- a/src/object/wrappers.rs
+++ b/src/object/wrappers.rs
@@ -70,6 +70,12 @@ pub mod generic {
         }
     }
 
+    impl<T> Shared<T> {
+        pub(crate) fn new_sized(val: T) -> Self {
+            Shared(std::rc::Rc::new(val))
+        }
+    }
+
     #[repr(transparent)]
     #[derive(Debug)]
     pub struct SharedMut<T>(std::rc::Rc<std::cell::RefCell<T>>);
@@ -165,6 +171,12 @@ pub mod generic {
 
         fn deref(&self) -> &Self::Target {
             &self.0
+        }
+    }
+
+    impl<T> Shared<T> {
+        pub(crate) fn new_sized(val: T) -> Self {
+            Shared(std::sync::Arc::new(val))
         }
     }
 

--- a/src/object/wrappers.rs
+++ b/src/object/wrappers.rs
@@ -71,8 +71,17 @@ pub mod generic {
     }
 
     #[repr(transparent)]
-    #[derive(Clone, Debug)]
+    #[derive(Debug)]
     pub struct SharedMut<T>(std::rc::Rc<std::cell::RefCell<T>>);
+
+    // `#[derive(Clone)]` would synthesize `T: Clone` — but `Rc` clones
+    // without that bound, and callers rely on sharing non-Clone inner
+    // types (terminals, sockets, …).
+    impl<T> Clone for SharedMut<T> {
+        fn clone(&self) -> Self {
+            SharedMut(self.0.clone())
+        }
+    }
 
     impl<T> SharedMut<T> {
         pub fn new(val: T) -> Self {
@@ -160,8 +169,15 @@ pub mod generic {
     }
 
     #[repr(transparent)]
-    #[derive(Clone, Debug)]
+    #[derive(Debug)]
     pub struct SharedMut<T>(std::sync::Arc<std::sync::RwLock<T>>);
+
+    impl<T> Clone for SharedMut<T> {
+        fn clone(&self) -> Self {
+            SharedMut(self.0.clone())
+        }
+    }
+
     impl<T> SharedMut<T> {
         pub fn new(val: T) -> Self {
             SharedMut(std::sync::Arc::new(std::sync::RwLock::new(val)))

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,20 +1,21 @@
 use crate::{
     Number, TulispObject,
     cons::Cons,
-    context::Scope,
     error::Error,
     object::{
         Span,
         wrappers::{
             TulispFn,
-            generic::{Shared, SyncSend},
+            generic::{Shared, SharedMut, SyncSend},
         },
     },
 };
 use std::{
     any::Any,
+    cell::RefCell,
     convert::TryInto,
     fmt::{Display, Write},
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 #[doc(hidden)]
@@ -38,7 +39,6 @@ impl std::fmt::Display for DefunParam {
 #[derive(Debug, Default, Clone)]
 pub struct DefunParams {
     params: Vec<DefunParam>,
-    scope: Scope,
 }
 
 impl std::fmt::Display for DefunParams {
@@ -74,7 +74,6 @@ impl TryFrom<TulispObject> for DefunParams {
                 is_rest = true;
                 continue;
             }
-            def_params.scope.scope.push(param.clone());
             def_params.params.push(DefunParam {
                 param,
                 is_rest,
@@ -98,8 +97,28 @@ impl DefunParams {
         self.params.iter()
     }
 
-    pub(crate) fn unbind(&self) -> Result<(), Error> {
-        self.scope.remove_all()
+    /// Replaces each raw-symbol param with a fresh `LexicalBinding` and
+    /// returns `(new_params, mappings)` where `mappings` is a list of
+    /// `(old_symbol, new_binding)` pairs suitable for
+    /// `substitute_lexical`. Callers are expected to run that
+    /// substitution on the function/macro body once at definition time,
+    /// so call-time evaluation only needs to push/pop values on each
+    /// binding's thread-local stack.
+    pub(crate) fn bind_as_lexical(
+        self,
+    ) -> (DefunParams, Vec<(TulispObject, TulispObject)>) {
+        let mut mappings = Vec::with_capacity(self.params.len());
+        let mut new_params = Vec::with_capacity(self.params.len());
+        for dp in self.params {
+            let lex = TulispObject::lexical_binding(dp.param.clone());
+            mappings.push((dp.param, lex.clone()));
+            new_params.push(DefunParam {
+                param: lex,
+                is_rest: dp.is_rest,
+                is_optional: dp.is_optional,
+            });
+        }
+        (DefunParams { params: new_params }, mappings)
     }
 }
 
@@ -156,16 +175,6 @@ impl SymbolBindings {
         }
         self.items.push(to_set);
         Ok(())
-    }
-
-    /// Sets the value without checking if the symbol is constant, or if it is
-    /// bound.
-    ///
-    /// For use in loops and other places where a set_scope has already been
-    /// done, and the symbol is known to be bound.
-    #[inline(always)]
-    pub(crate) fn set_unchecked(&mut self, to_set: TulispObject) {
-        *self.items.last_mut().unwrap() = to_set;
     }
 
     #[inline(always)]
@@ -225,6 +234,184 @@ impl SymbolBindings {
     }
 }
 
+// Thread-local item stacks for lexical bindings. A LexBinding is shared
+// across threads (one per defun/lambda param, allocated once at
+// creation); but each thread has its own push/pop stack indexed by the
+// binding's id. This lets concurrent calls into the same function —
+// e.g. tulisp-async timers — bind parameters independently, without
+// the cross-thread `Vec` aliasing that was Bug #3.
+//
+// Each stack entry is a `SharedMut<TulispObject>` — an actual cell
+// shared with any closures that captured this scope. `setq` mutates
+// the cell contents in place, so closures see the update (this is
+// what Emacs' `lexical-binding: t` semantics require, distinct from
+// snapshot-at-capture Scheme semantics). When the scope exits, the
+// stack pops the cell; any closures that cloned the `SharedMut` keep
+// it alive.
+//
+// The Vec grows to `max(id) + 1` per thread; see
+// docs/lexical-binding.md for the growth/cleanup tradeoffs we
+// explicitly accept (free-list is a deferred optimization).
+static LEX_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+thread_local! {
+    static LEX_STACKS: RefCell<Vec<Vec<SharedMut<TulispObject>>>> =
+        const { RefCell::new(Vec::new()) };
+}
+
+#[inline(always)]
+fn with_lex_stack<R>(id: u64, f: impl FnOnce(&mut Vec<SharedMut<TulispObject>>) -> R) -> R {
+    LEX_STACKS.with(|s| {
+        let mut v = s.borrow_mut();
+        let idx = id as usize;
+        if v.len() <= idx {
+            v.resize_with(idx + 1, Vec::new);
+        }
+        f(&mut v[idx])
+    })
+}
+
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub struct LexBinding {
+    id: u64,
+    name: String,
+    symbol: TulispObject,
+    // Captured bindings (from closures) hold a direct reference to the
+    // same shared slot that was on the enclosing scope's stack at
+    // capture time. Mutations to the enclosing scope's binding are
+    // therefore visible to the closure and vice-versa — matching
+    // Emacs' `lexical-binding: t` semantics. Param/let bindings leave
+    // this `None` and reach their slot through the thread-local stack
+    // indexed by `id`, which is faster and avoids cross-thread Vec
+    // aliasing (Bug #3).
+    captured: Option<SharedMut<TulispObject>>,
+}
+
+impl LexBinding {
+    pub(crate) fn new(symbol: TulispObject) -> Self {
+        let id = LEX_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let name = symbol.to_string();
+        LexBinding {
+            id,
+            name,
+            symbol,
+            captured: None,
+        }
+    }
+
+    /// Creates a captured binding that shares `slot` with the
+    /// originating scope. Used by lambda's `capture_variables`.
+    pub(crate) fn new_captured(symbol: TulispObject, slot: SharedMut<TulispObject>) -> Self {
+        let id = LEX_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let name = symbol.to_string();
+        LexBinding {
+            id,
+            name,
+            symbol,
+            captured: Some(slot),
+        }
+    }
+
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub(crate) fn symbol(&self) -> &TulispObject {
+        &self.symbol
+    }
+
+    /// Returns the `SharedMut` slot that currently holds this
+    /// binding's value, or `None` if it's unbound. Used by closure
+    /// capture so the closure can share the slot rather than snapshot.
+    #[inline(always)]
+    pub(crate) fn current_slot(&self) -> Option<SharedMut<TulispObject>> {
+        if let Some(slot) = &self.captured {
+            return Some(slot.clone());
+        }
+        with_lex_stack(self.id, |s| s.last().cloned())
+    }
+
+    #[inline(always)]
+    pub(crate) fn push(&self, val: TulispObject) {
+        if let Some(slot) = &self.captured {
+            *slot.borrow_mut() = val;
+            return;
+        }
+        with_lex_stack(self.id, |s| s.push(SharedMut::new(val)));
+    }
+
+    #[inline(always)]
+    pub(crate) fn pop(&self) -> Result<(), Error> {
+        if self.captured.is_some() {
+            return Ok(());
+        }
+        let popped = with_lex_stack(self.id, |s| s.pop());
+        if popped.is_some() {
+            Ok(())
+        } else {
+            Err(Error::uninitialized(format!(
+                "Can't unbind from unassigned symbol: {}",
+                self.name
+            )))
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn set(&self, val: TulispObject) -> Result<(), Error> {
+        if let Some(slot) = &self.captured {
+            *slot.borrow_mut() = val;
+            return Ok(());
+        }
+        with_lex_stack(self.id, |s| {
+            if let Some(last) = s.last() {
+                *last.borrow_mut() = val;
+            } else {
+                s.push(SharedMut::new(val));
+            }
+        });
+        Ok(())
+    }
+
+    #[inline(always)]
+    pub(crate) fn set_scope(&self, val: TulispObject) {
+        if let Some(slot) = &self.captured {
+            *slot.borrow_mut() = val;
+            return;
+        }
+        with_lex_stack(self.id, |s| s.push(SharedMut::new(val)));
+    }
+
+    #[inline(always)]
+    pub(crate) fn get(&self) -> Result<TulispObject, Error> {
+        if let Some(slot) = &self.captured {
+            return Ok(slot.borrow().clone());
+        }
+        let got = with_lex_stack(self.id, |s| s.last().map(|slot| slot.borrow().clone()));
+        got.ok_or_else(|| {
+            Error::uninitialized(format!("Variable definition is void: {}", self.name))
+        })
+    }
+
+    #[inline(always)]
+    pub(crate) fn boundp(&self) -> bool {
+        if self.captured.is_some() {
+            return true;
+        }
+        with_lex_stack(self.id, |s| !s.is_empty())
+    }
+
+    #[inline(always)]
+    pub(crate) fn get_as_number(&self) -> Result<Number, Error> {
+        self.get()?.as_number()
+    }
+
+    #[inline(always)]
+    pub(crate) fn get_as_bool(&self) -> Result<bool, Error> {
+        Ok(self.get()?.is_truthy())
+    }
+}
+
 pub trait TulispAny: Any + Display + SyncSend {}
 
 impl std::fmt::Debug for dyn TulispAny {
@@ -244,8 +431,7 @@ pub enum TulispValue {
         value: SymbolBindings,
     },
     LexicalBinding {
-        value: SymbolBindings,
-        symbol: TulispObject,
+        binding: LexBinding,
     },
     Number {
         value: Number,
@@ -297,10 +483,10 @@ impl std::fmt::Debug for TulispValue {
                 .field("name", &value.name)
                 .field("value", value)
                 .finish(),
-            Self::LexicalBinding { value, symbol } => f
+            Self::LexicalBinding { binding } => f
                 .debug_struct("LexicalBinding")
-                .field("symbol", symbol)
-                .field("value", value)
+                .field("symbol", binding.symbol())
+                .field("name", &binding.name())
                 .finish(),
             Self::Number { value } => f.debug_struct("Number").field("value", value).finish(),
             Self::String { value } => f.debug_struct("String").field("value", value).finish(),
@@ -390,7 +576,7 @@ impl std::fmt::Display for TulispValue {
             TulispValue::Bounce => f.write_str("Bounce"),
             TulispValue::Nil => f.write_str("nil"),
             TulispValue::Symbol { value } => f.write_str(&value.name),
-            TulispValue::LexicalBinding { value, .. } => f.write_str(&value.name),
+            TulispValue::LexicalBinding { binding } => f.write_str(binding.name()),
             TulispValue::Number { value, .. } => f.write_fmt(format_args!("{}", value)),
             TulispValue::String { value, .. } => f.write_fmt(format_args!(r#""{}""#, value)),
             vv @ TulispValue::List { .. } => {
@@ -427,76 +613,68 @@ impl TulispValue {
 
     #[inline(always)]
     pub(crate) fn lexical_binding(symbol: TulispObject) -> TulispValue {
-        let name = symbol.to_string();
         TulispValue::LexicalBinding {
-            symbol,
-            value: SymbolBindings {
-                name,
-                constant: false,
-                has_global: false,
-                items: Default::default(),
-            },
+            binding: LexBinding::new(symbol),
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn lexical_binding_captured(
+        symbol: TulispObject,
+        slot: SharedMut<TulispObject>,
+    ) -> TulispValue {
+        TulispValue::LexicalBinding {
+            binding: LexBinding::new_captured(symbol, slot),
         }
     }
 
     #[inline(always)]
     pub(crate) fn set(&mut self, to_set: TulispObject) -> Result<(), Error> {
-        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
-        {
-            value.set(to_set)
-        } else {
-            Err(Error::type_mismatch(
+        match self {
+            TulispValue::Symbol { value } => value.set(to_set),
+            TulispValue::LexicalBinding { binding } => binding.set(to_set),
+            _ => Err(Error::type_mismatch(
                 "Can bind values only to Symbols".to_string(),
-            ))
+            )),
         }
     }
 
     #[inline(always)]
     pub(crate) fn set_global(&mut self, to_set: TulispObject) -> Result<(), Error> {
-        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
-        {
-            value.set_global(to_set)
-        } else {
-            Err(Error::type_mismatch(
+        match self {
+            TulispValue::Symbol { value } => value.set_global(to_set),
+            // LexicalBindings have no "global" slot — setting the
+            // global cell of a lexical binding is nonsensical. Fall
+            // through to the same error as non-symbols.
+            _ => Err(Error::type_mismatch(
                 "Can bind values only to Symbols".to_string(),
-            ))
+            )),
         }
     }
 
     #[inline(always)]
     pub(crate) fn set_scope(&mut self, to_set: TulispObject) -> Result<(), Error> {
-        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
-        {
-            value.set_scope(to_set)
-        } else {
-            Err(Error::type_mismatch(format!(
+        match self {
+            TulispValue::Symbol { value } => value.set_scope(to_set),
+            TulispValue::LexicalBinding { binding } => {
+                binding.set_scope(to_set);
+                Ok(())
+            }
+            _ => Err(Error::type_mismatch(format!(
                 "Expected Symbol: Can't assign to {self}"
-            )))
+            ))),
         }
     }
 
     /// Sets the value without checking if the symbol is constant, or if it is
-    /// bound.
-    ///
-    /// For use in loops and other places where a set_scope has already been
-    /// done, and the symbol is known to be bound.
-    #[inline(always)]
-    pub(crate) fn set_unchecked(&mut self, to_set: TulispObject) {
-        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
-        {
-            value.set_unchecked(to_set)
-        }
-    }
-
     #[inline(always)]
     pub(crate) fn unset(&mut self) -> Result<(), Error> {
-        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
-        {
-            value.unset()
-        } else {
-            Err(Error::type_mismatch(
+        match self {
+            TulispValue::Symbol { value } => value.unset(),
+            TulispValue::LexicalBinding { binding } => binding.pop(),
+            _ => Err(Error::type_mismatch(
                 "Can unbind only from Symbols".to_string(),
-            ))
+            )),
         }
     }
 
@@ -514,30 +692,32 @@ impl TulispValue {
 
     #[inline(always)]
     pub(crate) fn lex_symbol_eq(&self, other: &TulispObject) -> bool {
-        let TulispValue::LexicalBinding { symbol, .. } = self else {
+        let TulispValue::LexicalBinding { binding } = self else {
             return false;
         };
-        if let TulispValue::LexicalBinding { symbol: other, .. } = &other.inner_ref().0 {
-            symbol.eq(other)
+        let self_sym = binding.symbol();
+        if let TulispValue::LexicalBinding { binding: other_b } = &other.inner_ref().0 {
+            self_sym.eq(other_b.symbol())
         } else {
-            symbol.eq(other)
+            self_sym.eq(other)
         }
     }
 
     #[inline(always)]
     pub(crate) fn get(&self) -> Result<TulispObject, Error> {
-        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
-        {
-            if value.is_constant() {
-                // Taking this path loses the span, so it should never be used.
-                // This check needs to be done in the object.
-                return Ok(self.clone().into_ref(None));
+        match self {
+            TulispValue::Symbol { value } => {
+                if value.is_constant() {
+                    // Taking this path loses the span, so it should never be
+                    // used. This check needs to be done in the object.
+                    return Ok(self.clone().into_ref(None));
+                }
+                value.get()
             }
-            value.get()
-        } else {
-            Err(Error::type_mismatch(
+            TulispValue::LexicalBinding { binding } => binding.get(),
+            _ => Err(Error::type_mismatch(
                 "Can get only from Symbols".to_string(),
-            ))
+            )),
         }
     }
 
@@ -552,11 +732,10 @@ impl TulispValue {
 
     #[inline(always)]
     pub(crate) fn boundp(&self) -> bool {
-        if let TulispValue::Symbol { value, .. } | TulispValue::LexicalBinding { value, .. } = self
-        {
-            value.boundp()
-        } else {
-            false
+        match self {
+            TulispValue::Symbol { value } => value.boundp(),
+            TulispValue::LexicalBinding { binding } => binding.boundp(),
+            _ => false,
         }
     }
 
@@ -621,9 +800,8 @@ impl TulispValue {
     #[inline(always)]
     pub(crate) fn as_symbol(&self) -> Result<String, Error> {
         match self {
-            TulispValue::Symbol { value } | TulispValue::LexicalBinding { value, .. } => {
-                Ok(value.name.to_string())
-            }
+            TulispValue::Symbol { value } => Ok(value.name.to_string()),
+            TulispValue::LexicalBinding { binding } => Ok(binding.name().to_string()),
             _ => Err(Error::type_mismatch(format!(
                 "Expected symbol, got: {}",
                 self

--- a/src/value.rs
+++ b/src/value.rs
@@ -106,6 +106,7 @@ impl DefunParams {
     /// binding's thread-local stack.
     pub(crate) fn bind_as_lexical(
         self,
+        allocator: &Shared<LexAllocator>,
     ) -> (DefunParams, Vec<(TulispObject, TulispObject)>) {
         let mut mappings = Vec::with_capacity(self.params.len());
         let mut new_params = Vec::with_capacity(self.params.len());
@@ -116,7 +117,7 @@ impl DefunParams {
             // of a special var binds dynamically, but function
             // parameters stay lexical. Matching that keeps semantics
             // consistent with Emacs' byte-compiler.
-            let lex = TulispObject::lexical_binding(dp.param.clone());
+            let lex = TulispObject::lexical_binding(allocator.clone(), dp.param.clone());
             mappings.push((dp.param, lex.clone()));
             new_params.push(DefunParam {
                 param: lex,
@@ -274,7 +275,47 @@ impl SymbolBindings {
 // The Vec grows to `max(id) + 1` per thread; see
 // docs/lexical-binding.md for the growth/cleanup tradeoffs we
 // explicitly accept (free-list is a deferred optimization).
+// Global monotonic id counter. Shared across all contexts so that
+// `LEX_STACKS` (thread-local, Vec-indexed by id) never sees collisions
+// when multiple contexts coexist. Atomic, not a mutex — no contention
+// concern. Growth is bounded in practice: each `LexAllocator` reuses
+// freed ids through its own free list before bumping this counter.
 static LEX_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Per-context allocator for LexBinding ids. Held by the context and
+/// by every `LexBinding` it creates (via a `Shared` ref on the
+/// binding), so dropping a binding returns its id to the free list —
+/// no global mutex needed. Under the default (non-`sync`) build this
+/// is a `RefCell` internally; under `sync` it's an `RwLock`.
+#[derive(Debug)]
+pub(crate) struct LexAllocator {
+    free_list: SharedMut<Vec<u64>>,
+}
+
+impl Default for LexAllocator {
+    fn default() -> Self {
+        LexAllocator {
+            free_list: SharedMut::new(Vec::new()),
+        }
+    }
+}
+
+impl LexAllocator {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+
+    fn alloc(&self) -> u64 {
+        if let Some(id) = self.free_list.borrow_mut().pop() {
+            return id;
+        }
+        LEX_COUNTER.fetch_add(1, Ordering::Relaxed)
+    }
+
+    fn free(&self, id: u64) {
+        self.free_list.borrow_mut().push(id);
+    }
+}
 
 thread_local! {
     static LEX_STACKS: RefCell<Vec<Vec<SharedMut<TulispObject>>>> =
@@ -293,9 +334,8 @@ fn with_lex_stack<R>(id: u64, f: impl FnOnce(&mut Vec<SharedMut<TulispObject>>) 
     })
 }
 
-#[doc(hidden)]
-#[derive(Clone, Debug)]
-pub struct LexBinding {
+#[derive(Debug)]
+struct LexBindingInner {
     id: u64,
     name: String,
     symbol: TulispObject,
@@ -308,39 +348,66 @@ pub struct LexBinding {
     // indexed by `id`, which is faster and avoids cross-thread Vec
     // aliasing (Bug #3).
     captured: Option<SharedMut<TulispObject>>,
+    // Back-pointer to the allocator that minted this id. When the last
+    // `Shared<LexBindingInner>` reference drops, we return the id here
+    // so the next allocation can reuse it — keeping `LEX_STACKS` from
+    // growing indefinitely.
+    allocator: Shared<LexAllocator>,
+}
+
+impl Drop for LexBindingInner {
+    fn drop(&mut self) {
+        self.allocator.free(self.id);
+    }
+}
+
+#[doc(hidden)]
+#[derive(Clone, Debug)]
+pub struct LexBinding {
+    inner: Shared<LexBindingInner>,
 }
 
 impl LexBinding {
-    pub(crate) fn new(symbol: TulispObject) -> Self {
-        let id = LEX_COUNTER.fetch_add(1, Ordering::Relaxed);
+    pub(crate) fn new(allocator: Shared<LexAllocator>, symbol: TulispObject) -> Self {
+        let id = allocator.alloc();
         let name = symbol.to_string();
         LexBinding {
-            id,
-            name,
-            symbol,
-            captured: None,
+            inner: Shared::new_sized(LexBindingInner {
+                id,
+                name,
+                symbol,
+                captured: None,
+                allocator,
+            }),
         }
     }
 
     /// Creates a captured binding that shares `slot` with the
     /// originating scope. Used by lambda's `capture_variables`.
-    pub(crate) fn new_captured(symbol: TulispObject, slot: SharedMut<TulispObject>) -> Self {
-        let id = LEX_COUNTER.fetch_add(1, Ordering::Relaxed);
+    pub(crate) fn new_captured(
+        allocator: Shared<LexAllocator>,
+        symbol: TulispObject,
+        slot: SharedMut<TulispObject>,
+    ) -> Self {
+        let id = allocator.alloc();
         let name = symbol.to_string();
         LexBinding {
-            id,
-            name,
-            symbol,
-            captured: Some(slot),
+            inner: Shared::new_sized(LexBindingInner {
+                id,
+                name,
+                symbol,
+                captured: Some(slot),
+                allocator,
+            }),
         }
     }
 
     pub(crate) fn name(&self) -> &str {
-        &self.name
+        &self.inner.name
     }
 
     pub(crate) fn symbol(&self) -> &TulispObject {
-        &self.symbol
+        &self.inner.symbol
     }
 
     /// Returns the `SharedMut` slot that currently holds this
@@ -348,44 +415,44 @@ impl LexBinding {
     /// capture so the closure can share the slot rather than snapshot.
     #[inline(always)]
     pub(crate) fn current_slot(&self) -> Option<SharedMut<TulispObject>> {
-        if let Some(slot) = &self.captured {
+        if let Some(slot) = &self.inner.captured {
             return Some(slot.clone());
         }
-        with_lex_stack(self.id, |s| s.last().cloned())
+        with_lex_stack(self.inner.id, |s| s.last().cloned())
     }
 
     #[inline(always)]
     pub(crate) fn push(&self, val: TulispObject) {
-        if let Some(slot) = &self.captured {
+        if let Some(slot) = &self.inner.captured {
             *slot.borrow_mut() = val;
             return;
         }
-        with_lex_stack(self.id, |s| s.push(SharedMut::new(val)));
+        with_lex_stack(self.inner.id, |s| s.push(SharedMut::new(val)));
     }
 
     #[inline(always)]
     pub(crate) fn pop(&self) -> Result<(), Error> {
-        if self.captured.is_some() {
+        if self.inner.captured.is_some() {
             return Ok(());
         }
-        let popped = with_lex_stack(self.id, |s| s.pop());
+        let popped = with_lex_stack(self.inner.id, |s| s.pop());
         if popped.is_some() {
             Ok(())
         } else {
             Err(Error::uninitialized(format!(
                 "Can't unbind from unassigned symbol: {}",
-                self.name
+                self.inner.name
             )))
         }
     }
 
     #[inline(always)]
     pub(crate) fn set(&self, val: TulispObject) -> Result<(), Error> {
-        if let Some(slot) = &self.captured {
+        if let Some(slot) = &self.inner.captured {
             *slot.borrow_mut() = val;
             return Ok(());
         }
-        with_lex_stack(self.id, |s| {
+        with_lex_stack(self.inner.id, |s| {
             if let Some(last) = s.last() {
                 *last.borrow_mut() = val;
             } else {
@@ -397,30 +464,30 @@ impl LexBinding {
 
     #[inline(always)]
     pub(crate) fn set_scope(&self, val: TulispObject) {
-        if let Some(slot) = &self.captured {
+        if let Some(slot) = &self.inner.captured {
             *slot.borrow_mut() = val;
             return;
         }
-        with_lex_stack(self.id, |s| s.push(SharedMut::new(val)));
+        with_lex_stack(self.inner.id, |s| s.push(SharedMut::new(val)));
     }
 
     #[inline(always)]
     pub(crate) fn get(&self) -> Result<TulispObject, Error> {
-        if let Some(slot) = &self.captured {
+        if let Some(slot) = &self.inner.captured {
             return Ok(slot.borrow().clone());
         }
-        let got = with_lex_stack(self.id, |s| s.last().map(|slot| slot.borrow().clone()));
+        let got = with_lex_stack(self.inner.id, |s| s.last().map(|slot| slot.borrow().clone()));
         got.ok_or_else(|| {
-            Error::uninitialized(format!("Variable definition is void: {}", self.name))
+            Error::uninitialized(format!("Variable definition is void: {}", self.inner.name))
         })
     }
 
     #[inline(always)]
     pub(crate) fn boundp(&self) -> bool {
-        if self.captured.is_some() {
+        if self.inner.captured.is_some() {
             return true;
         }
-        with_lex_stack(self.id, |s| !s.is_empty())
+        with_lex_stack(self.inner.id, |s| !s.is_empty())
     }
 
     #[inline(always)]
@@ -635,19 +702,23 @@ impl TulispValue {
     }
 
     #[inline(always)]
-    pub(crate) fn lexical_binding(symbol: TulispObject) -> TulispValue {
+    pub(crate) fn lexical_binding(
+        allocator: Shared<LexAllocator>,
+        symbol: TulispObject,
+    ) -> TulispValue {
         TulispValue::LexicalBinding {
-            binding: LexBinding::new(symbol),
+            binding: LexBinding::new(allocator, symbol),
         }
     }
 
     #[inline(always)]
     pub(crate) fn lexical_binding_captured(
+        allocator: Shared<LexAllocator>,
         symbol: TulispObject,
         slot: SharedMut<TulispObject>,
     ) -> TulispValue {
         TulispValue::LexicalBinding {
-            binding: LexBinding::new_captured(symbol, slot),
+            binding: LexBinding::new_captured(allocator, symbol, slot),
         }
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -110,6 +110,12 @@ impl DefunParams {
         let mut mappings = Vec::with_capacity(self.params.len());
         let mut new_params = Vec::with_capacity(self.params.len());
         for dp in self.params {
+            // Defun/lambda params are always lexically bound — even
+            // when the symbol has been declared `defvar` (special).
+            // Emacs under `lexical-binding: t` behaves this way: `let`
+            // of a special var binds dynamically, but function
+            // parameters stay lexical. Matching that keeps semantics
+            // consistent with Emacs' byte-compiler.
             let lex = TulispObject::lexical_binding(dp.param.clone());
             mappings.push((dp.param, lex.clone()));
             new_params.push(DefunParam {
@@ -126,6 +132,12 @@ impl DefunParams {
 pub struct SymbolBindings {
     name: String,
     constant: bool,
+    // "Special" (dynamic) in Emacs' terminology: `defvar`-declared.
+    // Once set, references to this symbol bypass lexical-binding
+    // rewrites (substitute_lexical / capture) and always use this
+    // symbol's own `items` stack, matching Emacs' behavior under
+    // `lexical-binding: t` for declared variables.
+    special: bool,
     has_global: bool,
     items: Vec<TulispObject>,
 }
@@ -231,6 +243,16 @@ impl SymbolBindings {
     #[inline(always)]
     pub(crate) fn is_constant(&self) -> bool {
         self.constant
+    }
+
+    #[inline(always)]
+    pub(crate) fn is_special(&self) -> bool {
+        self.special
+    }
+
+    #[inline(always)]
+    pub(crate) fn set_special(&mut self) {
+        self.special = true;
     }
 }
 
@@ -605,6 +627,7 @@ impl TulispValue {
             value: SymbolBindings {
                 name,
                 constant,
+                special: false,
                 has_global: false,
                 items: Default::default(),
             },
@@ -682,11 +705,35 @@ impl TulispValue {
     pub(crate) fn is_lexically_bound(&self) -> bool {
         match self {
             TulispValue::Symbol { value } => {
+                if value.special {
+                    return false;
+                }
                 (value.has_global && value.items.len() > 1)
                     || (!value.has_global && !value.items.is_empty())
             }
             TulispValue::LexicalBinding { .. } => true,
             _ => false,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn is_special(&self) -> bool {
+        match self {
+            TulispValue::Symbol { value } => value.is_special(),
+            _ => false,
+        }
+    }
+
+    #[inline(always)]
+    pub(crate) fn set_special(&mut self) -> Result<(), Error> {
+        match self {
+            TulispValue::Symbol { value } => {
+                value.set_special();
+                Ok(())
+            }
+            _ => Err(Error::type_mismatch(
+                "set_special requires a symbol".to_string(),
+            )),
         }
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1152,6 +1152,148 @@ fn test_lexical_binding() -> Result<(), Error> {
         result: "720",
     }
 
+    // Regression: literal symbol in a backquote alist key position must
+    // NOT be rewritten even when it shares a name with a lambda param.
+    // With the bug present, `k` in `(k . literal)` would be substituted
+    // to a LexicalBinding wrapper, so `(assoc 'k entry)` would miss.
+    tulisp_assert! {
+        program: r#"
+        (defun make-entry (k v)
+          `((key . ,k) (value . ,v) (k . literal-k)))
+        (let ((entry (make-entry 'foo 42)))
+          (list (cdr (assoc 'key entry))
+                (cdr (assoc 'value entry))
+                (cdr (assoc 'k entry))))
+        "#,
+        result: "'(foo 42 literal-k)",
+    }
+
+    // Regression: `(quote X)` written as a list form must not be
+    // descended into for substitution, even if X names a defun param.
+    // With the bug present, `(quote key)` would rewrite the literal
+    // `key` symbol, breaking the subsequent `(assoc 'key ...)`.
+    tulisp_assert! {
+        program: r#"
+        (defun pick (key alist)
+          (cdr (assoc (quote key) alist)))
+        (pick 'ignored '((key . the-key-value) (other . o)))
+        "#,
+        result: "'the-key-value",
+    }
+
+    // Regression: a backquote whose unquoted data contains literal
+    // symbols matching enclosing lambda params must stay usable as a
+    // lambda form. The bug turned inner literal keys into
+    // LexicalBindings, which then errored when the stored form was
+    // re-evaluated by funcall.
+    tulisp_assert! {
+        program: r#"
+        (defun make-resetter (items)
+          `(lambda ()
+             (dolist (item (quote ,items))
+               (cdr (assoc 'value item)))))
+        (let ((form (make-resetter '(((value . 1)) ((value . 2))))))
+          (funcall (eval form))
+          'ok)
+        "#,
+        result: "'ok",
+    }
+
+    Ok(())
+}
+
+// `defvar`-declared variables are dynamic (special) — references resolve
+// through the symbol's own stack, so eval-in-a-different-scope sees the
+// enclosing binding. This matches Emacs' behavior under `lexical-binding: t`.
+#[test]
+fn test_defvar_dynamic_binding() -> Result<(), Error> {
+    // With defvar, eval in a different function scope sees the let
+    // binding through the symbol's dynamic stack — the let binding pushes onto
+    // the symbol's dynamic stack, and eval inside run-eval sees it.
+    tulisp_assert! {
+        program: r#"
+        (defvar xdyn nil)
+        (defun run-eval (form) (eval form))
+        (let ((xdyn 7))
+          (run-eval 'xdyn))
+        "#,
+        result: "7",
+    }
+
+    // The backquote-quoted-and-eval'd-later pattern — works once the
+    // variable is defvar'd so dynamic binding survives the scope jump.
+    tulisp_assert! {
+        program: r#"
+        (defvar xbq nil)
+        (defun run-eval (form) (eval form))
+        (let ((xbq 42))
+          (run-eval '`(+ ,xbq 1)))
+        "#,
+        result: "'(+ 42 1)",
+    }
+
+    // setq on a dynamic var in outer scope is visible after let scope
+    // exits: the global slot gets updated, not a fresh lex slot.
+    tulisp_assert! {
+        program: r#"
+        (defvar counter 0)
+        (defun bump () (setq counter (+ counter 1)))
+        (bump) (bump) (bump)
+        counter
+        "#,
+        result: "3",
+    }
+
+    // Dynamic binding unwinds properly on let exit — outer value is
+    // restored.
+    tulisp_assert! {
+        program: r#"
+        (defvar k 100)
+        (let ((k 1))
+          (let ((k 2)) k)
+          k)
+        "#,
+        result: "1",
+    }
+
+    // A closure referencing a dynamic var reads the current dynamic
+    // binding at call time, not a snapshot from capture time.
+    tulisp_assert! {
+        program: r#"
+        (defvar d 1)
+        (setq f (lambda () d))
+        (let ((d 99))
+          (funcall f))
+        "#,
+        result: "99",
+    }
+
+    // Defun/lambda parameters are lexically bound even when the name
+    // was declared `defvar` — matching Emacs' byte-compiler under
+    // `lexical-binding: t`. The param binding does not shadow the
+    // dynamic global, so another function that references the same
+    // symbol sees the outer dynamic value, not the caller's arg.
+    tulisp_assert! {
+        program: r#"
+        (defvar p 10)
+        (defun observe () p)
+        (defun with-p (p) (observe))
+        (with-p 55)
+        "#,
+        result: "10",
+    }
+
+    // Direct reference to the param inside the defun sees the lex
+    // binding even though the name is defvar'd.
+    tulisp_assert! {
+        program: r#"
+        (defvar p2 10)
+        (defun read-param (p2) p2)
+        (read-param 55)
+        "#,
+        result: "55",
+    }
+
     Ok(())
 }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -951,6 +951,207 @@ fn test_lexical_binding() -> Result<(), Error> {
         result: "'(((a . t)))",
     }
 
+    // 'symbol is a literal — a defun param with the same name must not
+    // rewrite it into a variable reference.
+    tulisp_assert! {
+        program: r#"
+        (defun lookup-a (a data) (alist-get 'a data))
+        (lookup-a 999 '((a . 1) (b . 2)))
+        "#,
+        result: "1",
+    }
+
+    // '(…) list literals stay literal even when they contain names that
+    // match lex bindings in the surrounding scope.
+    tulisp_assert! {
+        program: r#"
+        (defun keys-of (x) '(a b x))
+        (keys-of 42)
+        "#,
+        result: "'(a b x)",
+    }
+
+    // Nested closures: each inner lambda captures its own enclosing var.
+    tulisp_assert! {
+        program: r#"
+        (defun outer (x)
+          (lambda (y)
+            (lambda (z) (+ x y z))))
+        (funcall (funcall (outer 100) 20) 3)
+        "#,
+        result: "123",
+    }
+
+    // Closure invoked after outer let scope has exited — captured slot
+    // must still hold the value.
+    tulisp_assert! {
+        program: r#"
+        (setq g (let ((k 7)) (lambda () k)))
+        (funcall g)
+        "#,
+        result: "7",
+    }
+
+    // setq on a captured variable inside a closure persists across
+    // invocations (classic counter pattern).
+    tulisp_assert! {
+        program: r#"
+        (defun make-counter ()
+          (let ((n 0))
+            (lambda () (setq n (+ n 1)) n)))
+        (setq c (make-counter))
+        (list (funcall c) (funcall c) (funcall c))
+        "#,
+        result: "'(1 2 3)",
+    }
+
+    // Two counters built from the same factory are independent.
+    tulisp_assert! {
+        program: r#"
+        (defun make-counter ()
+          (let ((n 0))
+            (lambda () (setq n (+ n 1)) n)))
+        (setq a (make-counter))
+        (setq b (make-counter))
+        (funcall a) (funcall a) (funcall b)
+        (list (funcall a) (funcall b))
+        "#,
+        result: "'(3 2)",
+    }
+
+    // A lambda parameter shadows an outer lex binding of the same name.
+    tulisp_assert! {
+        program: r#"
+        (let ((x 100))
+          (funcall (lambda (x) (* x 2)) 7))
+        "#,
+        result: "14",
+    }
+
+    // Quote inside backquote: 'a stays literal, ,b is substituted.
+    tulisp_assert! {
+        program: r#"
+        (let ((b 42))
+          `('a ,b))
+        "#,
+        result: "'('a 42)",
+    }
+
+    // let* sequential binding — later bindings see earlier ones.
+    tulisp_assert! {
+        program: r#"
+        (let* ((a 1) (b (+ a 10)) (c (+ a b))) (list a b c))
+        "#,
+        result: "'(1 11 12)",
+    }
+
+    // dolist under Emacs' `lexical-binding: t` binds the loop variable
+    // freshly at each iteration (roughly `(while tail (let ((i (car
+    // tail))) body))`), so each captured closure sees its own value.
+    tulisp_assert! {
+        program: r#"
+        (setq fns nil)
+        (dolist (i '(1 2 3))
+          (setq fns (cons (lambda () i) fns)))
+        (mapcar 'funcall fns)
+        "#,
+        result: "'(3 2 1)",
+    }
+
+    // dotimes behaves like dolist: fresh binding per iteration.
+    tulisp_assert! {
+        program: r#"
+        (setq fns nil)
+        (dotimes (j 3)
+          (setq fns (cons (lambda () j) fns)))
+        (mapcar 'funcall fns)
+        "#,
+        result: "'(2 1 0)",
+    }
+
+    // setq on a let-bound variable inside the let scope propagates to a
+    // closure that captured the same binding (Emacs behavior — the
+    // closure and the enclosing scope share the slot).
+    tulisp_assert! {
+        program: r#"
+        (let ((x 1))
+          (setq f (lambda () x))
+          (setq x 42))
+        (funcall f)
+        "#,
+        result: "42",
+    }
+
+    // setq on a defun parameter is visible to a closure constructed
+    // earlier inside the same defun.
+    tulisp_assert! {
+        program: r#"
+        (defun outer-mutating (x)
+          (let ((g (lambda () x)))
+            (setq x 99)
+            (funcall g)))
+        (outer-mutating 1)
+        "#,
+        result: "99",
+    }
+
+    // Two closures that captured the same let-binding share the slot,
+    // so `setq` in one is visible to the other.
+    tulisp_assert! {
+        program: r#"
+        (let ((n 0))
+          (setq inc (lambda () (setq n (+ n 1)) n))
+          (setq read-n (lambda () n)))
+        (funcall inc)
+        (funcall inc)
+        (funcall read-n)
+        "#,
+        result: "2",
+    }
+
+    // Backquote constructed in one scope, eval'd inside another
+    // function. The unquoted value is captured at construction time so
+    // the inner eval only needs to see already-resolved literals.
+    tulisp_assert! {
+        program: r#"
+        (defun run-eval (form) (eval form))
+        (let ((id 99))
+          (run-eval `(+ ,id 1)))
+        "#,
+        result: "100",
+    }
+
+    // Captured var reads the current value at capture time; later
+    // rebinding of the original symbol does not affect the closure.
+    tulisp_assert! {
+        program: r#"
+        (setq f (let ((x 1)) (lambda () x)))
+        (setq x 999)
+        (funcall f)
+        "#,
+        result: "1",
+    }
+
+    // A closure in a list can still be invoked via funcall after list
+    // operations (doesn't rely on stack-top semantics).
+    tulisp_assert! {
+        program: r#"
+        (setq fs (mapcar (lambda (n) (lambda () n)) '(10 20 30)))
+        (mapcar 'funcall fs)
+        "#,
+        result: "'(10 20 30)",
+    }
+
+    // Recursive defun sees its own lex params correctly across calls.
+    tulisp_assert! {
+        program: r#"
+        (defun fact (n)
+          (if (<= n 1) 1 (* n (fact (- n 1)))))
+        (fact 6)
+        "#,
+        result: "720",
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- Switches the tree-walker to Emacs `lexical-binding: t` — `let` and
  lambda params bind lexically; closures share the slot with the
  enclosing scope so `setq` is visible across the boundary.
- `defvar` is the dynamic-binding escape hatch, with RAII cleanup of
  captured slots in let bindings and constructed lambdas.
