### PR TITLE
Let Rust registrations override prelude definitions

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -292,9 +292,31 @@ impl TulispContext {
                 .insert(name.to_owned(), caller.line() as usize);
         }
 
-        self.intern(name)
-            .set_global(TulispValue::Func(Shared::new_tulisp_fn(func)).into_ref(None))
+        let sym = self.intern(name);
+        sym.set_global(TulispValue::Func(Shared::new_tulisp_fn(func)).into_ref(None))
             .unwrap();
+        self.evict_compiled_dispatch(sym.addr_as_usize());
+    }
+
+    /// Drop any compile-time call-dispatch entry recorded for `addr`.
+    ///
+    /// A name first introduced by a Lisp `defun` (notably the built-in
+    /// prelude) wires `addr -> compile_fn_defun_call` into
+    /// `vm_compilers.functions` and stores its `CompiledDefun` in
+    /// `bytecode.functions`. `compile_form` consults that map *before*
+    /// the symbol's global cell, so a later Rust `defun` / `defspecial`
+    /// — which only writes the global cell — would be silently
+    /// shadowed. Evicting both entries makes subsequent user code
+    /// compile against the freshly-registered global binding.
+    ///
+    /// No-op while the compiler is still being built (during
+    /// `TulispContext::new`, the Rust built-ins register before the
+    /// compiler exists), where there is nothing to evict yet.
+    fn evict_compiled_dispatch(&mut self, addr: usize) {
+        if let Some(compiler) = self.compiler.as_mut() {
+            compiler.vm_compilers.functions.remove(&addr);
+            compiler.bytecode.functions.remove(&addr);
+        }
     }
 
     /// Internal: register a `ctx.defun`-style typed-args closure as a
@@ -324,15 +346,16 @@ impl TulispContext {
                 .insert(name.to_owned(), caller.line() as usize);
         }
 
-        self.intern(name)
-            .set_global(
-                TulispValue::Defun {
-                    call: Shared::new_defun_fn(func),
-                    arity,
-                }
-                .into_ref(None),
-            )
-            .unwrap();
+        let sym = self.intern(name);
+        sym.set_global(
+            TulispValue::Defun {
+                call: Shared::new_defun_fn(func),
+                arity,
+            }
+            .into_ref(None),
+        )
+        .unwrap();
+        self.evict_compiled_dispatch(sym.addr_as_usize());
     }
 
     /// Registers a Rust function as a callable Lisp function.
@@ -465,9 +488,10 @@ impl TulispContext {
                 .insert(name.to_owned(), caller.line() as usize);
         }
 
-        self.intern(name)
-            .set_global(TulispValue::Macro(Shared::new_tulisp_fn(func)).into_ref(None))
+        let sym = self.intern(name);
+        sym.set_global(TulispValue::Macro(Shared::new_tulisp_fn(func)).into_ref(None))
             .unwrap();
+        self.evict_compiled_dispatch(sym.addr_as_usize());
     }
 
     pub fn set_load_path<P: AsRef<Path>>(&mut self, path: Option<P>) -> Result<(), Error> {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -401,6 +401,37 @@ fn test_defun() -> Result<(), Error> {
 }
 
 #[test]
+fn test_rust_registration_overrides_prelude_defun() -> Result<(), Error> {
+    // A Rust `defun` registered for a name the built-in prelude
+    // already defines (here `sort`) must win for code compiled after
+    // the registration. Regression: the prelude's `defun` wires the
+    // name into the VM compiler's call-dispatch table, which
+    // `compile_form` consulted before the symbol's global cell —
+    // silently shadowing the Rust override on the VM path.
+    let mut ctx = TulispContext::new();
+    ctx.defun(
+        "sort",
+        |_seq: TulispObject, _pred: TulispObject| -> String { "rust-sort".to_string() },
+    );
+    tulisp_assert! {
+        ctx: ctx,
+        program: r#"(sort '(3 1 2) (lambda (a b) (< a b)))"#,
+        result: r#""rust-sort""#,
+    }
+
+    // A later `defspecial` for the same name re-overrides it: the
+    // eviction is idempotent across repeated registrations.
+    ctx.defspecial("sort", |_ctx, _args| Ok("special-sort".into()));
+    tulisp_assert! {
+        ctx: ctx,
+        program: r#"(sort '(3 1 2) (lambda (a b) (< a b)))"#,
+        result: r#""special-sort""#,
+    }
+
+    Ok(())
+}
+
+#[test]
 fn test_tco() -> Result<(), Error> {
     tulisp_assert! {
         program: r##"


### PR DESCRIPTION
A name first defined by a Lisp `defun` — notably the built-in prelude — registers its compiled-call dispatch in the compiler's `vm_compilers.functions` table and its `CompiledDefun` in `bytecode.functions`. `compile_form` consults that table before the symbol's global cell, but `ctx.defun` / `defspecial` / `defmacro` write only the global cell. So a direct call compiled on the VM path kept resolving to the prelude definition and the Rust override was silently shadowed — `funcall`/`apply` and the tree-walker already honored it, which made the asymmetry confusing.

Evict the stale compile-dispatch entry when a Rust function or macro is registered, so code compiled afterward resolves against the new global binding. The VM machine's own `bytecode.functions` is left intact, so the prelude's internal callers keep their pre-compiled binding.